### PR TITLE
feat: v0.4.0 — ripgrep-compatible search UX and AI-friendly API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-13
+
+### Added
+- Smart-case search by default — all-lowercase patterns match case-insensitively, any uppercase letter makes the search case-sensitive
+- `-s` / `--case-sensitive` flag to force case-sensitive search (disables smart-case)
+- `-A` / `--after-context` and `-B` / `--before-context` for asymmetric context lines (ripgrep-compatible)
+- `-w` / `--word-regexp` for whole-word matching
+- `-g` / `--glob` include/exclude path filters — `!` prefix excludes, repeatable (ripgrep-compatible)
+- Fluent builder methods on `SearchOptions` (`new()`, `with_case_insensitive()`, `with_regex()`, `with_file_type()`, `with_max_count()`, `with_word()`, `with_glob()`, `with_changed_only()`, `with_fresh()`) — additive, struct-literal construction still works
+- `IndexStatusInfo` / `IndexState` structured types returned by `index_status()`, so agents can branch on index state without parsing prose
+- `docs/agents.md` guide for AI agent integration (MCP setup, `--format llm`, exit codes, environment variables, recipes)
+- napi (Node.js) bindings expose the `word` and `globs` search options and a structured `indexStatus()` object
+
+### Changed
+- **Breaking:** Search is now smart-case by default instead of always case-sensitive — all-lowercase patterns now match case-insensitively. Pass `-s` to restore strict matching
+- **Breaking:** `Xgrep::index_status()` now returns `Result<IndexStatusInfo>` instead of `Result<String>` — call `.to_string()` on the result for the previous human-readable output
+- **Breaking:** `SearchOptions` gained `word` and `globs` fields — struct-literal construction must initialize them (the new builder methods avoid this)
+- MCP `index_status` tool now returns a structured JSON object (`state`, `indexed_files`, `index_size_bytes`, `index_path`) instead of a prose string
+
+### Fixed
+- 2-char pattern candidate resolution now unions prefix and suffix trigrams, fixing missed matches when a 2-char pattern occurs at end-of-file
+
 ## [0.3.0] - 2026-04-01
 
 ### Added
@@ -123,7 +145,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parallel file scanning with rayon
 - SIMD-accelerated pattern matching via memchr
 
-[Unreleased]: https://github.com/momokun7/xgrep/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/momokun7/xgrep/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/momokun7/xgrep/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/momokun7/xgrep/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/momokun7/xgrep/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/momokun7/xgrep/compare/v0.1.6...v0.2.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pre-builds a trigram inverted index, then searches in milliseconds. Designed for
 ## Features
 
 - **Indexed search** — trigram inverted index makes repeated searches 2-46x faster than ripgrep
-- **File discovery** — `--find` mode locates files 4-34x faster than fd/find
+- **File discovery** — `--find` mode locates files 2-15x faster than fd
 - **MCP server** — built-in [Model Context Protocol](https://modelcontextprotocol.io/) server for AI coding tools (Claude Code, Cursor, etc.)
 - **LLM-optimized output** — `--format llm` produces Markdown with language tags, context lines, and token-aware truncation
 - **Git-aware** — search only changed files (`--changed`), recent commits (`--since 1h`), respects `.gitignore`
@@ -128,12 +128,12 @@ Benchmarked with [hyperfine](https://github.com/sharkdp/hyperfine) on Apple M4, 
 | `printk` | 52ms | 1,756ms | **34x faster** |
 | `EXPORT_SYMBOL` | 66ms | 1,773ms | **27x faster** |
 
-### File discovery: next.js (26,424 files)
+### File discovery: next.js (27,332 files)
 
 | Query | xg --find | fd | vs fd |
 |-------|-----------|-----|-------|
-| `*.ts` (4,643 files) | 8.9ms | 190.9ms | **21x faster** |
-| `config` (substring) | 5.5ms | 189.0ms | **34x faster** |
+| `*.ts` (4,838 files) | 20.8ms | 187.3ms | **9x faster** |
+| `config` (substring) | 12.7ms | 188.1ms | **15x faster** |
 
 ### Index cost
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ xg serve --root /path/to/repo   # Specific directory
 
 **Available tools:** `search`, `find_definitions`, `read_file`, `index_status`, `build_index`
 
+See [docs/agents.md](docs/agents.md) for agent-oriented usage patterns.
+
 ## Performance
 
 Benchmarked with [hyperfine](https://github.com/sharkdp/hyperfine) on Apple M4, 32GB RAM, macOS. All numbers are warm cache, after index build.

--- a/README.md
+++ b/README.md
@@ -55,11 +55,18 @@ cp target/release/xg ~/.local/bin/
 ## Usage
 
 ```bash
-xg "pattern"                  # Fixed string search
+xg "pattern"                  # Smart-case search (all-lowercase = case-insensitive)
+xg "Pattern"                  # Mixed/upper case in pattern = case-sensitive
+xg "pattern" -i               # Force case-insensitive
+xg "pattern" -s               # Force case-sensitive (disable smart-case)
 xg "pattern" /path/to/repo    # Search a specific directory
 xg -e "handle_\w+"            # Regex search
+xg "pattern" -w               # Match whole words only
 xg "pattern" -t rs            # Filter by file type
-xg "pattern" -C 3             # Context lines
+xg "pattern" -C 3             # Context lines (symmetric)
+xg "pattern" -A 2 -B 1        # 2 lines after, 1 line before
+xg "pattern" -g "*.rs"        # Include only paths matching glob (repeatable)
+xg "pattern" -g "!*_test.rs"  # Exclude paths matching glob (! prefix)
 xg "pattern" --format llm     # Markdown output for LLMs
 xg "pattern" --changed        # Only git changed files
 xg "pattern" --exclude vendor  # Exclude paths containing "vendor"
@@ -70,6 +77,8 @@ xg --list-types               # Show supported file types
 xg status                     # Show index status
 xg init                       # Explicitly rebuild index
 ```
+
+Search is **smart-case** by default: an all-lowercase pattern matches case-insensitively, while any uppercase letter makes the search case-sensitive. Use `-i` or `-s` to override (priority: `-i` > `-s` > smart-case).
 
 ### Environment Variables
 
@@ -139,6 +148,7 @@ Benchmarked with [hyperfine](https://github.com/sharkdp/hyperfine) on Apple M4, 
 ## Limitations
 
 - **Short queries (< 3 chars)** bypass the index — no speed advantage over ripgrep
+- **Tiny files (< 3 bytes)** hold no trigrams and are invisible to indexed content search — a deliberate trade-off of the trigram index
 - **Index staleness** — background rebuild runs every ~30s. Use `--fresh` for up-to-date results
 - **find_definitions** uses regex heuristics, not AST analysis — false positives expected
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,142 @@
+# Using xgrep from AI Agents
+
+xgrep is an indexed code search engine fast enough to call inside an agent loop
+(typically tens of milliseconds on large repos), with token-aware Markdown
+output and a built-in MCP server so AI coding tools can search a codebase
+natively instead of re-scanning it on every query.
+
+## Quick reference (CLI)
+
+```bash
+xg "pattern" /path --format llm   # Markdown output sized for context windows
+```
+
+- **Exit codes:** `0` = matches found, `1` = no matches (not an error), `2` = error.
+- **Path argument is optional.** Omit it to search the current directory, or pass
+  an absolute path to search a specific repo without `cd`.
+
+### Environment variables
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `XGREP_LLM_CONTEXT` | Default context lines for `--format llm` | `3` |
+| `XGREP_ABSOLUTE_PATHS` | Set to `1` to always emit absolute paths | unset |
+| `XGREP_NO_HINTS` | Set to `1` to suppress regex pattern hints on stderr | unset |
+
+### Useful one-liners
+
+```bash
+# Smart-case is the default: an all-lowercase pattern is case-insensitive.
+# Force case-sensitive matching with -s:
+xg "Parser" /path -s --format llm
+
+# Word-boundary match (-w): "cat" matches "the cat" but not "concatenate"
+xg "cat" /path -w --format llm
+
+# Include / exclude by glob (-g). Prefix with ! to exclude. Repeatable:
+xg "TODO" /path -g "*.rs" -g "!*_test.rs" --format llm
+
+# Asymmetric context: 0 lines before, 10 lines after each match
+xg "fn handle_request" /path -B 0 -A 10 --format llm
+
+# Filter by file type and limit results
+xg "import" /path -t py --max-count 20 --format llm
+```
+
+## MCP server
+
+Start the server over stdio:
+
+```bash
+xg serve                        # current directory
+xg serve --root /path/to/repo   # specific directory
+```
+
+Register it with Claude Code (`.mcp.json` or settings):
+
+```json
+{
+  "mcpServers": {
+    "xgrep": {
+      "command": "xg",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+### Tools
+
+| Tool | Purpose | Key parameters |
+|------|---------|----------------|
+| `search` | Trigram-indexed pattern search returning matching lines with context. | `pattern` (required), `regex`, `case_insensitive`, `file_type`, `path_pattern`, `max_results` (default 20), `context_lines` (default 3), `max_tokens` (default 4000) |
+| `find_definitions` | Locate likely symbol definitions via regex heuristics (`fn`/`struct`/`class`/`def`…). Not AST-based; may include false positives. | `symbol` (required), `file_type`, `path_pattern` |
+| `read_file` | Read a file (optionally a line range) with line numbers. Use after `search` for full context. | `path` (required, relative to project root), `start_line`, `end_line` |
+| `index_status` | Report index health. Returns JSON: `state` (`"fresh"`, `"stale (N changed files)"`, or `"missing"`), `indexed_files`, `index_size_bytes`, `index_path`. | none |
+| `build_index` | Build or rebuild the search index for the codebase. | none |
+
+The `index_status` JSON lets an agent branch on freshness without parsing prose:
+call `build_index` when `state` is `"missing"`, or proceed directly when `state`
+is `"fresh"`.
+
+## Recipes for agents
+
+```bash
+# 1. Find where a symbol is defined (definitions only, not call sites)
+xg -e "(?:pub\s+)?(?:fn|struct|enum|trait)\s+TokenStream\b" /path -t rs --format llm
+# (the find_definitions MCP tool wraps this heuristic for you)
+
+# 2. Search only files changed since the last commit (fast, scoped review)
+xg "unwrap\(\)" /path --changed -e --format llm
+
+# 3. Repeated search on a large repo — the first call builds the index,
+#    subsequent calls reuse it and return in milliseconds
+xg "deprecated" /path --format llm
+xg "TODO"       /path --format llm   # reuses the warm index
+
+# 4. Filter by type AND glob to narrow a noisy match
+xg "Config" /path -t rs -g "!**/tests/**" --format llm
+
+# 5. Asymmetric context to read more code *after* each match (e.g. function bodies)
+xg "fn build_index" /path -B 0 -A 20 --format llm
+```
+
+## Library (Rust)
+
+Add the crate and drive it directly. Options use a fluent builder, so you never
+need an exhaustive struct literal:
+
+```rust
+use xgrep_search::{Xgrep, SearchOptions, IndexState};
+
+let xg = Xgrep::open(".")?;
+xg.build_index()?;
+
+let opts = SearchOptions::new()
+    .with_case_insensitive(true)
+    .with_file_type("rs")
+    .with_max_count(20)
+    .with_glob("!*_test.rs");
+
+for r in xg.search("fn main", &opts)? {
+    println!("{}:{}: {}", r.file, r.line_number, r.line);
+}
+# Ok::<(), xgrep_search::XgrepError>(())
+```
+
+`index_status()` returns a structured `IndexStatusInfo` you can branch on
+without string parsing (its `Display` impl reproduces the `xg status` text):
+
+```rust
+use xgrep_search::{Xgrep, IndexState};
+
+let xg = Xgrep::open(".")?;
+let info = xg.index_status()?;
+match info.state {
+    IndexState::Fresh => println!("up to date ({} files)", info.indexed_files),
+    IndexState::Stale { changed_files } => println!("{} files changed", changed_files),
+    IndexState::Missing => xg.build_index()?,
+}
+println!("index: {} bytes at {}", info.index_size_bytes, info.index_path.display());
+# Ok::<(), xgrep_search::XgrepError>(())
+```

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -72,7 +72,7 @@ Register it with Claude Code (`.mcp.json` or settings):
 | `search` | Trigram-indexed pattern search returning matching lines with context. | `pattern` (required), `regex`, `case_insensitive`, `file_type`, `path_pattern`, `max_results` (default 20), `context_lines` (default 3), `max_tokens` (default 4000) |
 | `find_definitions` | Locate likely symbol definitions via regex heuristics (`fn`/`struct`/`class`/`def`…). Not AST-based; may include false positives. | `symbol` (required), `file_type`, `path_pattern` |
 | `read_file` | Read a file (optionally a line range) with line numbers. Use after `search` for full context. | `path` (required, relative to project root), `start_line`, `end_line` |
-| `index_status` | Report index health. Returns JSON: `state` (`"fresh"`, `"stale (N changed files)"`, or `"missing"`), `indexed_files`, `index_size_bytes`, `index_path`. | none |
+| `index_status` | Report index health. Returns JSON: `state` (`"fresh"`, `"stale"`, or `"missing"`), `changed_files` (count, present only when `state` is `"stale"`), `indexed_files`, `index_size_bytes`, `index_path`. | none |
 | `build_index` | Build or rebuild the search index for the codebase. | none |
 
 The `index_status` JSON lets an agent branch on freshness without parsing prose:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -37,12 +37,12 @@ Benchmarked with [hyperfine](https://github.com/sharkdp/hyperfine) on Apple M4, 
 | `*.rs` (769 files) | 1.9ms | 7.7ms | 6.5ms | **4.1x faster** |
 | `config` (substring) | 1.6ms | 7.2ms | 6.5ms | **4.5x faster** |
 
-### next.js (26,464 files, React framework)
+### next.js (27,332 files, React framework)
 
 | Query | xg --find | fd | find | vs fd |
 |-------|-----------|-----|------|-------|
-| `*.ts` (4,643 files) | 8.9ms | 190.9ms | 558.7ms | **21x faster** |
-| `config` (substring) | 5.5ms | 189.0ms | 559.4ms | **34x faster** |
+| `*.ts` (4,838 files) | 20.8ms | 187.3ms | 632.8ms | **9x faster** |
+| `config` (substring) | 12.7ms | 188.1ms | 521.1ms | **15x faster** |
 
 `xg --find` reads file paths from the in-memory index (mmap), while fd/find walk the filesystem. The gap widens with repository size.
 

--- a/npm/Cargo.lock
+++ b/npm/Cargo.lock
@@ -275,6 +275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,7 +568,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -706,7 +712,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -714,6 +729,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -959,11 +985,12 @@ dependencies = [
 
 [[package]]
 name = "xgrep-search"
-version = "0.1.5"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
  "dirs-next",
+ "glob",
  "ignore",
  "libc",
  "memchr",
@@ -974,6 +1001,7 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "xxhash-rust",
 ]
 

--- a/npm/Cargo.lock
+++ b/npm/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "xgrep-search"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/npm/__test__/index.mjs
+++ b/npm/__test__/index.mjs
@@ -43,9 +43,23 @@ try {
   assert.strictEqual(noResults.length, 0, 'should return empty for no match');
   console.log('ok: empty results');
 
-  // Index status
+  // Word-boundary search
+  const wordResults = xg.search('hello', { word: true });
+  assert.ok(wordResults.length > 0, 'word search should match standalone "hello"');
+  console.log('ok: word-boundary search');
+
+  // Glob filter (include only .rs)
+  const globResults = xg.search('fn', { globs: ['*.rs'] });
+  assert.ok(globResults.every(r => r.file.endsWith('.rs')), 'glob should restrict to .rs');
+  console.log('ok: glob filter');
+
+  // Index status (structured object)
   const status = xg.indexStatus();
-  assert.ok(status.includes('Index path:'), 'status should contain index path');
+  assert.strictEqual(typeof status, 'object', 'status should be an object');
+  assert.strictEqual(status.state, 'fresh', 'state should be fresh after build');
+  assert.ok(status.indexedFiles >= 1, 'indexedFiles should count built files');
+  assert.ok(status.indexSizeBytes > 0, 'indexSizeBytes should be positive');
+  assert.ok(status.indexPath.length > 0, 'indexPath should be set');
   console.log('ok: indexStatus');
 
   // Error handling: search on non-indexed repo should still work (fallback)

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -30,6 +30,29 @@ export interface SearchOptions {
   pathPattern?: string
   /** Check index freshness before searching. */
   fresh?: boolean
+  /**
+   * Match only at word boundaries (wraps the pattern in `(?:...)`).
+   * Enabling this always runs the regex engine, even for literal patterns.
+   */
+  word?: boolean
+  /**
+   * Include/exclude result paths by glob (ripgrep -g compatible).
+   * Prefix a glob with `!` to exclude. Empty/omitted = no filtering.
+   */
+  globs?: Array<string>
+}
+/** Index status returned from xgrep. */
+export interface IndexStatus {
+  /** Freshness state: "fresh", "stale", or "missing". */
+  state: string
+  /** Number of files changed since the last build. Present only when state is "stale". */
+  changedFiles?: number
+  /** Number of files in the index (0 if missing). */
+  indexedFiles: number
+  /** Index file size in bytes (0 if missing). */
+  indexSizeBytes: number
+  /** Path to the index file. */
+  indexPath: string
 }
 /** Ultra-fast indexed code search engine. */
 export declare class Xgrep {
@@ -41,8 +64,8 @@ export declare class Xgrep {
   buildIndex(): void
   /** Search for a pattern in the indexed codebase. */
   search(pattern: string, opts?: SearchOptions | undefined | null): Array<SearchResult>
-  /** Get the current index status. */
-  indexStatus(): string
+  /** Get the current index status as a structured object. */
+  indexStatus(): IndexStatus
   /** Get the root directory path. */
   get root(): string
   /** Get the index file path. */

--- a/npm/src/lib.rs
+++ b/npm/src/lib.rs
@@ -31,6 +31,27 @@ pub struct SearchOptions {
     pub path_pattern: Option<String>,
     /// Check index freshness before searching.
     pub fresh: Option<bool>,
+    /// Match only at word boundaries (wraps the pattern in `\b(?:...)\b`).
+    /// Enabling this always runs the regex engine, even for literal patterns.
+    pub word: Option<bool>,
+    /// Include/exclude result paths by glob (ripgrep -g compatible).
+    /// Prefix a glob with `!` to exclude. Empty/omitted = no filtering.
+    pub globs: Option<Vec<String>>,
+}
+
+/// Index status returned from xgrep.
+#[napi(object)]
+pub struct IndexStatus {
+    /// Freshness state: "fresh", "stale", or "missing".
+    pub state: String,
+    /// Number of files changed since the last build. Present only when state is "stale".
+    pub changed_files: Option<u32>,
+    /// Number of files in the index (0 if missing).
+    pub indexed_files: u32,
+    /// Index file size in bytes (0 if missing).
+    pub index_size_bytes: i64,
+    /// Path to the index file.
+    pub index_path: String,
 }
 
 /// Ultra-fast indexed code search engine.
@@ -80,12 +101,14 @@ impl Xgrep {
         Ok(results.into_iter().map(to_js_result).collect())
     }
 
-    /// Get the current index status.
+    /// Get the current index status as a structured object.
     #[napi]
-    pub fn index_status(&self) -> Result<String> {
-        self.inner
+    pub fn index_status(&self) -> Result<IndexStatus> {
+        let info = self
+            .inner
             .index_status()
-            .map_err(|e| Error::from_reason(e.to_string()))
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(to_js_status(info))
     }
 
     /// Get the root directory path.
@@ -113,7 +136,26 @@ fn to_rust_opts(opts: Option<SearchOptions>) -> xgrep_search::SearchOptions {
             since: o.since,
             path_pattern: o.path_pattern,
             fresh: o.fresh.unwrap_or(false),
+            word: o.word.unwrap_or(false),
+            globs: o.globs.unwrap_or_default(),
         },
+    }
+}
+
+fn to_js_status(info: xgrep_search::IndexStatusInfo) -> IndexStatus {
+    let (state, changed_files) = match info.state {
+        xgrep_search::IndexState::Fresh => ("fresh".to_string(), None),
+        xgrep_search::IndexState::Stale { changed_files } => {
+            ("stale".to_string(), Some(changed_files as u32))
+        }
+        xgrep_search::IndexState::Missing => ("missing".to_string(), None),
+    };
+    IndexStatus {
+        state,
+        changed_files,
+        indexed_files: info.indexed_files as u32,
+        index_size_bytes: info.index_size_bytes as i64,
+        index_path: info.index_path.to_string_lossy().to_string(),
     }
 }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "xgrep-search"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xgrep-search"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Ultra-fast indexed code search engine with MCP server for AI coding tools."

--- a/rust/src/candidates.rs
+++ b/rust/src/candidates.rs
@@ -54,13 +54,16 @@ pub(crate) fn resolve_literal_candidates(
         }
     } else if trigrams.is_empty() {
         if pattern_bytes.len() == 2 {
-            let prefix = [pattern_bytes[0], pattern_bytes[1]];
-            let candidates = reader.lookup_trigram_prefix(prefix);
-            if candidates.is_empty() {
-                (0..reader.file_count()).collect()
-            } else {
-                candidates
-            }
+            // A 2-byte pattern in any file of >= 3 bytes must produce either
+            // trigram "ab?" (prefix) or "?ab" (suffix). Files smaller than
+            // 3 bytes have no trigrams and are invisible to content search
+            // (documented index design limitation).
+            let pair = [pattern_bytes[0], pattern_bytes[1]];
+            let mut candidates = reader.lookup_trigram_prefix(pair);
+            candidates.extend(reader.lookup_trigram_suffix(pair));
+            candidates.sort_unstable();
+            candidates.dedup();
+            candidates
         } else {
             (0..reader.file_count()).collect()
         }

--- a/rust/src/globfilter.rs
+++ b/rust/src/globfilter.rs
@@ -1,0 +1,93 @@
+//! Glob-based result filtering for the -g/--glob flag (ripgrep-compatible).
+
+use crate::error::{Result, XgrepError};
+
+/// Compiled include/exclude glob filters.
+///
+/// Globs without a path separator also match against any path depth
+/// (`*.rs` behaves like `**/*.rs`), mirroring ripgrep's -g semantics.
+pub(crate) struct GlobFilter {
+    includes: Vec<Vec<glob::Pattern>>,
+    excludes: Vec<Vec<glob::Pattern>>,
+}
+
+impl GlobFilter {
+    pub(crate) fn new(globs: &[String]) -> Result<Self> {
+        let mut includes = Vec::new();
+        let mut excludes = Vec::new();
+        for g in globs {
+            let (negated, body) = match g.strip_prefix('!') {
+                Some(rest) => (true, rest),
+                None => (false, g.as_str()),
+            };
+            let mut patterns = vec![compile(body, g)?];
+            if !body.contains('/') {
+                patterns.push(compile(&format!("**/{}", body), g)?);
+            }
+            if negated {
+                excludes.push(patterns);
+            } else {
+                includes.push(patterns);
+            }
+        }
+        Ok(Self { includes, excludes })
+    }
+
+    pub(crate) fn matches(&self, path: &str) -> bool {
+        let opts = glob::MatchOptions {
+            require_literal_separator: true,
+            ..Default::default()
+        };
+        let hit = |group: &[glob::Pattern]| group.iter().any(|p| p.matches_with(path, opts));
+        if self.excludes.iter().any(|group| hit(group)) {
+            return false;
+        }
+        self.includes.is_empty() || self.includes.iter().any(|group| hit(group))
+    }
+}
+
+fn compile(body: &str, original: &str) -> Result<glob::Pattern> {
+    glob::Pattern::new(body)
+        .map_err(|e| XgrepError::InvalidPattern(format!("invalid glob '{}': {}", original, e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn include_basename_glob_matches_any_depth() {
+        let f = GlobFilter::new(&["*.rs".to_string()]).unwrap();
+        assert!(f.matches("main.rs"));
+        assert!(f.matches("src/deep/lib.rs"));
+        assert!(!f.matches("src/lib.py"));
+    }
+
+    #[test]
+    fn exclude_glob() {
+        let f = GlobFilter::new(&["*.rs".to_string(), "!*_test.rs".to_string()]).unwrap();
+        assert!(f.matches("src/lib.rs"));
+        assert!(!f.matches("src/lib_test.rs"));
+    }
+
+    #[test]
+    fn path_glob_requires_separator_match() {
+        let f = GlobFilter::new(&["src/*.rs".to_string()]).unwrap();
+        assert!(f.matches("src/lib.rs"));
+        assert!(!f.matches("other/lib.rs"));
+        // require_literal_separator: '*' must not cross '/'
+        assert!(!f.matches("src/deep/lib.rs"));
+    }
+
+    #[test]
+    fn exclude_only_means_include_everything_else() {
+        let f = GlobFilter::new(&["!vendor/**".to_string()]).unwrap();
+        assert!(f.matches("src/lib.rs"));
+        assert!(!f.matches("vendor/x/y.js"));
+    }
+
+    #[test]
+    fn invalid_glob_is_error() {
+        assert!(GlobFilter::new(&["[invalid".to_string()]).is_err());
+    }
+}

--- a/rust/src/globfilter.rs
+++ b/rust/src/globfilter.rs
@@ -20,6 +20,9 @@ impl GlobFilter {
                 Some(rest) => (true, rest),
                 None => (false, g.as_str()),
             };
+            if body.is_empty() {
+                return Err(XgrepError::InvalidPattern(format!("empty glob '{}'", g)));
+            }
             let mut patterns = vec![compile(body, g)?];
             if !body.contains('/') {
                 patterns.push(compile(&format!("**/{}", body), g)?);
@@ -89,5 +92,11 @@ mod tests {
     #[test]
     fn invalid_glob_is_error() {
         assert!(GlobFilter::new(&["[invalid".to_string()]).is_err());
+    }
+
+    #[test]
+    fn empty_glob_is_error() {
+        assert!(GlobFilter::new(&["".to_string()]).is_err());
+        assert!(GlobFilter::new(&["!".to_string()]).is_err());
     }
 }

--- a/rust/src/index/reader.rs
+++ b/rust/src/index/reader.rs
@@ -280,6 +280,45 @@ impl IndexReader {
         seen.into_iter().collect()
     }
 
+    /// Return the union of posting lists for all trigrams `t` where
+    /// `t[1] == suffix[0] && t[2] == suffix[1]`.
+    ///
+    /// Used for 2-byte patterns: an occurrence of "ab" in a file of >= 3 bytes
+    /// is guaranteed to produce either trigram "ab?" (byte after) or "?ab"
+    /// (byte before). Because the trigram table is sorted by the full 3-byte
+    /// value, suffix-matching entries are not contiguous, so a linear scan over
+    /// the dictionary is used. This is acceptable because 2-byte queries are a
+    /// rare path. The returned vector is sorted and deduplicated.
+    pub(crate) fn lookup_trigram_suffix(&self, suffix: [u8; 2]) -> Vec<u32> {
+        let count = self.cached_header.trigram_count as usize;
+        if count == 0 {
+            return vec![];
+        }
+
+        let trigram_table_start = Header::SIZE;
+        let mut seen = std::collections::BTreeSet::new();
+        for i in 0..count {
+            let offset = trigram_table_start + i * TrigramEntry::SIZE;
+            if offset + TrigramEntry::SIZE > self.mmap.len() {
+                break;
+            }
+            let entry = read_trigram_entry(&self.mmap[offset..offset + TrigramEntry::SIZE]);
+            if entry.trigram[1] != suffix[0] || entry.trigram[2] != suffix[1] {
+                continue;
+            }
+            let pl_start = self.posting_lists_start + entry.posting_offset as usize;
+            let pl_end = pl_start + entry.posting_len as usize;
+            if pl_end > self.mmap.len() {
+                continue; // skip corrupted entry
+            }
+            let data = &self.mmap[pl_start..pl_end];
+            for fid in Self::decode_posting_list(data) {
+                seen.insert(fid);
+            }
+        }
+        seen.into_iter().collect()
+    }
+
     pub fn file_path(&self, file_id: u32) -> &str {
         if file_id >= self.cached_header.file_count {
             return "<invalid file_id>";

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -23,6 +23,7 @@ pub(crate) mod candidates;
 pub mod error;
 pub(crate) mod filetype;
 pub(crate) mod git;
+pub(crate) mod globfilter;
 pub mod hints;
 pub(crate) mod index;
 pub(crate) mod mcp;
@@ -114,6 +115,9 @@ pub struct SearchOptions {
     pub fresh: bool,
     /// Match only at word boundaries (wraps the pattern in `\b(?:...)\b`)
     pub word: bool,
+    /// Include/exclude result paths by glob (ripgrep -g compatible).
+    /// Prefix a glob with `!` to exclude. Empty = no filtering.
+    pub globs: Vec<String>,
 }
 
 /// Configuration for the search engine.
@@ -237,6 +241,12 @@ impl Xgrep {
         // path_pattern filter
         if let Some(ref pp) = opts.path_pattern {
             results.retain(|r| r.file.contains(pp));
+        }
+
+        // glob filter (-g)
+        if !opts.globs.is_empty() {
+            let filter = globfilter::GlobFilter::new(&opts.globs)?;
+            results.retain(|r| filter.matches(&r.file));
         }
 
         // max_count
@@ -1024,6 +1034,24 @@ mod tests {
         let results = xg.search("foo.bar", &opts).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].line.contains("foo.bar"));
+    }
+
+    #[test]
+    fn test_search_with_glob_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/a.rs"), "needle\n").unwrap();
+        std::fs::write(root.join("src/b.py"), "needle\n").unwrap();
+        let xg = Xgrep::open_local(root).unwrap();
+        xg.build_index().unwrap();
+        let opts = SearchOptions {
+            globs: vec!["*.rs".to_string()],
+            ..Default::default()
+        };
+        let results = xg.search("needle", &opts).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].file.ends_with("a.rs"));
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -46,6 +46,39 @@ pub use filetype::extensions_for_type;
 pub use filetype::list_all_types;
 pub use search::SearchResult;
 
+/// Returns true if the pattern contains an uppercase ASCII letter.
+///
+/// Used to implement smart-case: a pattern with no uppercase letters is
+/// searched case-insensitively unless the caller forces sensitivity.
+/// In regex mode, characters that form an escape sequence (e.g. `\W`, `\D`)
+/// are not treated as uppercase literals. `\\D` (escaped backslash followed
+/// by `D`) does count.
+///
+/// # Examples
+///
+/// ```
+/// use xgrep_search::pattern_has_uppercase;
+/// assert!(!pattern_has_uppercase("hello", false));
+/// assert!(pattern_has_uppercase("Hello", false));
+/// assert!(!pattern_has_uppercase(r"\W+foo", true));
+/// ```
+pub fn pattern_has_uppercase(pattern: &str, regex: bool) -> bool {
+    let bytes = pattern.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if regex && bytes[i] == b'\\' {
+            // Skip the escape sequence (backslash + next byte)
+            i += 2;
+            continue;
+        }
+        if bytes[i].is_ascii_uppercase() {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
 /// Return git changed files (unstaged + staged) relative to the given root.
 ///
 /// Returns paths relative to `root`. Includes unstaged changes, staged changes,
@@ -902,5 +935,41 @@ mod tests {
         xg.build_index().unwrap();
         let results = xg.search("zq", &SearchOptions::default()).unwrap();
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_pattern_has_uppercase_literal() {
+        assert!(!pattern_has_uppercase("hello", false));
+        assert!(pattern_has_uppercase("Hello", false));
+        assert!(!pattern_has_uppercase("123!", false));
+        // Literal mode: backslash is a literal character, W counts as uppercase
+        assert!(pattern_has_uppercase(r"\W", false));
+    }
+
+    #[test]
+    fn test_pattern_has_uppercase_regex_skips_escapes() {
+        // \W is a regex escape, not an uppercase literal
+        assert!(!pattern_has_uppercase(r"\W+foo", true));
+        assert!(pattern_has_uppercase(r"\W+Foo", true));
+        assert!(!pattern_has_uppercase(r"foo\d", true));
+        // Escaped backslash followed by uppercase: \\ is literal backslash, D is uppercase
+        assert!(pattern_has_uppercase(r"\\D", true));
+    }
+
+    /// Smart-case behavior verified at the library level via explicit flag:
+    /// the CLI maps (no -i, no -s, all-lowercase pattern) to case_insensitive=true.
+    #[test]
+    fn test_search_case_insensitive_finds_mixed_case() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("a.rs"), "fn HandleAuth() {}\n").unwrap();
+        let xg = Xgrep::open_local(root).unwrap();
+        xg.build_index().unwrap();
+        let opts = SearchOptions {
+            case_insensitive: true,
+            ..Default::default()
+        };
+        let results = xg.search("handleauth", &opts).unwrap();
+        assert_eq!(results.len(), 1);
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -464,6 +464,12 @@ impl Xgrep {
             )?
         };
 
+        // glob filter (-g)
+        if !opts.globs.is_empty() {
+            let filter = globfilter::GlobFilter::new(&opts.globs)?;
+            results.retain(|r| filter.matches(&r.file));
+        }
+
         if let Some(max) = opts.max_count {
             results.truncate(max);
         }
@@ -1067,5 +1073,23 @@ mod tests {
         };
         let results = xg.search("handleauth", &opts).unwrap();
         assert_eq!(results.len(), 1);
+    }
+
+    /// -g must be honored on the explicit-file search path too.
+    #[test]
+    fn test_search_files_applies_glob_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("a.py"), "needle\n").unwrap();
+        let xg = Xgrep::open_local(root).unwrap();
+        xg.build_index().unwrap();
+        let opts = SearchOptions {
+            globs: vec!["*.rs".to_string()],
+            ..Default::default()
+        };
+        let results = xg
+            .search_files(&[std::path::PathBuf::from("a.py")], "needle", &opts)
+            .unwrap();
+        assert!(results.is_empty(), "-g '*.rs' must filter out a .py file");
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,7 +7,12 @@
 //!
 //! let xg = Xgrep::open(".").unwrap();
 //! xg.build_index().unwrap();
-//! let results = xg.search("fn main", &SearchOptions::default()).unwrap();
+//!
+//! // Build options fluently — no exhaustive struct literal required.
+//! let opts = SearchOptions::new()
+//!     .with_file_type("rs")
+//!     .with_max_count(20);
+//! let results = xg.search("fn main", &opts).unwrap();
 //! for r in &results {
 //!     println!("{}:{}: {}", r.file, r.line_number, r.line);
 //! }
@@ -54,6 +59,10 @@ pub use search::SearchResult;
 /// In regex mode, characters that form an escape sequence (e.g. `\W`, `\D`)
 /// are not treated as uppercase literals. `\\D` (escaped backslash followed
 /// by `D`) does count.
+///
+/// Non-ASCII letters never count as uppercase, matching the engine's
+/// ASCII-only case folding. In regex mode a trailing backslash is treated as
+/// an incomplete escape and contributes no uppercase.
 ///
 /// # Examples
 ///
@@ -113,11 +122,80 @@ pub struct SearchOptions {
     /// Check index freshness and use hybrid search for changed files.
     /// When false (default), uses existing index as-is for maximum speed.
     pub fresh: bool,
-    /// Match only at word boundaries (wraps the pattern in `\b(?:...)\b`)
+    /// Match only at word boundaries (wraps the pattern in `\b(?:...)\b`).
+    /// Note: enabling this always runs the regex engine, even for literal patterns.
     pub word: bool,
     /// Include/exclude result paths by glob (ripgrep -g compatible).
     /// Prefix a glob with `!` to exclude. Empty = no filtering.
     pub globs: Vec<String>,
+}
+
+impl SearchOptions {
+    /// Create default search options (case-sensitive literal search, no filters).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xgrep_search::SearchOptions;
+    /// let opts = SearchOptions::new()
+    ///     .with_case_insensitive(true)
+    ///     .with_file_type("rs")
+    ///     .with_max_count(10);
+    /// assert!(opts.case_insensitive);
+    /// assert_eq!(opts.file_type.as_deref(), Some("rs"));
+    /// assert_eq!(opts.max_count, Some(10));
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set case-insensitive search (ASCII folding only).
+    pub fn with_case_insensitive(mut self, value: bool) -> Self {
+        self.case_insensitive = value;
+        self
+    }
+
+    /// Treat the pattern as a regex instead of a literal string.
+    pub fn with_regex(mut self, value: bool) -> Self {
+        self.regex = value;
+        self
+    }
+
+    /// Filter results by file type (e.g. `"rs"`, `"py"`, `"js"`).
+    pub fn with_file_type(mut self, file_type: impl Into<String>) -> Self {
+        self.file_type = Some(file_type.into());
+        self
+    }
+
+    /// Limit the number of results returned.
+    pub fn with_max_count(mut self, max: usize) -> Self {
+        self.max_count = Some(max);
+        self
+    }
+
+    /// Match only at word boundaries (always runs the regex engine).
+    pub fn with_word(mut self, value: bool) -> Self {
+        self.word = value;
+        self
+    }
+
+    /// Add an include/exclude glob (prefix with `!` to exclude). Repeatable.
+    pub fn with_glob(mut self, glob: impl Into<String>) -> Self {
+        self.globs.push(glob.into());
+        self
+    }
+
+    /// Restrict the search to files with uncommitted git changes.
+    pub fn with_changed_only(mut self, value: bool) -> Self {
+        self.changed_only = value;
+        self
+    }
+
+    /// Check index freshness and use hybrid search for changed files.
+    pub fn with_fresh(mut self, value: bool) -> Self {
+        self.fresh = value;
+        self
+    }
 }
 
 /// Configuration for the search engine.
@@ -131,6 +209,79 @@ pub struct Config {
     pub quiet: bool,
 }
 
+/// Index freshness state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexState {
+    /// Index is up to date.
+    Fresh,
+    /// Index exists but some files changed since the last build.
+    Stale {
+        /// Number of files changed since the last index build.
+        changed_files: usize,
+    },
+    /// No index has been built yet.
+    Missing,
+}
+
+/// Structured index status, returned by [`Xgrep::index_status`].
+///
+/// The [`Display`](std::fmt::Display) impl renders the human-readable status
+/// text used by the `xg status` CLI command.
+///
+/// # Examples
+///
+/// ```no_run
+/// use xgrep_search::{Xgrep, IndexState};
+///
+/// let xg = Xgrep::open(".").unwrap();
+/// let info = xg.index_status().unwrap();
+/// match info.state {
+///     IndexState::Fresh => println!("up to date ({} files)", info.indexed_files),
+///     IndexState::Stale { changed_files } => println!("{} files changed", changed_files),
+///     IndexState::Missing => println!("no index at {}", info.index_path.display()),
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct IndexStatusInfo {
+    /// Freshness state of the index.
+    pub state: IndexState,
+    /// Number of files in the index (0 if missing).
+    pub indexed_files: usize,
+    /// Index file size in bytes (0 if missing).
+    pub index_size_bytes: u64,
+    /// Path to the index file.
+    pub index_path: PathBuf,
+}
+
+impl std::fmt::Display for IndexStatusInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let status_str = match &self.state {
+            IndexState::Fresh => "fresh".to_string(),
+            IndexState::Stale { changed_files } => {
+                format!("stale ({} changed files)", changed_files)
+            }
+            IndexState::Missing => "no index".to_string(),
+        };
+        if matches!(self.state, IndexState::Missing) {
+            write!(
+                f,
+                "Status: {}\nIndex path: {}",
+                status_str,
+                self.index_path.display()
+            )
+        } else {
+            write!(
+                f,
+                "Status: {}\nIndexed files: {}\nIndex size: {} bytes\nIndex path: {}",
+                status_str,
+                self.indexed_files,
+                self.index_size_bytes,
+                self.index_path.display()
+            )
+        }
+    }
+}
+
 /// Main entry point for the search engine.
 ///
 /// Use `open()` to specify a directory, then `search()` to execute queries.
@@ -142,7 +293,7 @@ pub struct Xgrep {
 }
 
 impl Xgrep {
-    /// Open a directory. Index path is auto-resolved (.xgrep/index or ~/.cache/xgrep/<hash>/index).
+    /// Open a directory. Index path is auto-resolved (`.xgrep/index` or `~/.cache/xgrep/<hash>/index`).
     pub fn open(root: impl AsRef<Path>) -> Result<Self> {
         let root = root.as_ref().to_path_buf();
         let index_path = resolve_index_path(&root)?;
@@ -198,6 +349,8 @@ impl Xgrep {
 
     /// Apply word-boundary wrapping. Returns the effective pattern and
     /// whether it must be executed as a regex.
+    ///
+    /// Callees must use the returned bool instead of `opts.regex`.
     fn effective_pattern<'a>(
         pattern: &'a str,
         opts: &SearchOptions,
@@ -559,37 +712,41 @@ impl Xgrep {
         Ok(matched)
     }
 
-    /// Return index status information.
-    pub fn index_status(&self) -> Result<String> {
+    /// Return structured index status information.
+    ///
+    /// Use the [`IndexStatusInfo`] fields directly, or its
+    /// [`Display`](std::fmt::Display) impl for the human-readable text.
+    pub fn index_status(&self) -> Result<IndexStatusInfo> {
         let status = index::updater::check_index_status(&self.root, &self.index_path)?;
-        let status_str = match &status {
-            index::updater::IndexStatus::Fresh => "fresh".to_string(),
-            index::updater::IndexStatus::Stale { changed_files } => {
-                format!("stale ({} changed files)", changed_files.len())
-            }
-            index::updater::IndexStatus::NeedsFullBuild => "no index".to_string(),
+        let state = match &status {
+            index::updater::IndexStatus::Fresh => IndexState::Fresh,
+            index::updater::IndexStatus::Stale { changed_files } => IndexState::Stale {
+                changed_files: changed_files.len(),
+            },
+            index::updater::IndexStatus::NeedsFullBuild => IndexState::Missing,
         };
 
-        let index_info = if self.index_path.exists() {
-            let meta = std::fs::metadata(&self.index_path).ok();
-            let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
-            let reader = index::reader::IndexReader::open(&self.index_path).ok();
-            let file_count = reader.map(|r| r.file_count()).unwrap_or(0);
-            format!(
-                "Status: {}\nIndexed files: {}\nIndex size: {} bytes\nIndex path: {}",
-                status_str,
-                file_count,
-                size,
-                self.index_path.display()
-            )
+        if self.index_path.exists() {
+            let size = std::fs::metadata(&self.index_path)
+                .map(|m| m.len())
+                .unwrap_or(0);
+            let file_count = index::reader::IndexReader::open(&self.index_path)
+                .map(|r| r.file_count() as usize)
+                .unwrap_or(0);
+            Ok(IndexStatusInfo {
+                state,
+                indexed_files: file_count,
+                index_size_bytes: size,
+                index_path: self.index_path.clone(),
+            })
         } else {
-            format!(
-                "Status: {}\nIndex path: {}",
-                status_str,
-                self.index_path.display()
-            )
-        };
-        Ok(index_info)
+            Ok(IndexStatusInfo {
+                state: IndexState::Missing,
+                indexed_files: 0,
+                index_size_bytes: 0,
+                index_path: self.index_path.clone(),
+            })
+        }
     }
 }
 
@@ -988,6 +1145,41 @@ mod tests {
     }
 
     #[test]
+    fn test_search_options_builder() {
+        let opts = SearchOptions::new()
+            .with_case_insensitive(true)
+            .with_regex(true)
+            .with_file_type("rs")
+            .with_max_count(10)
+            .with_word(true)
+            .with_glob("*.rs")
+            .with_glob("!*_test.rs");
+        assert!(opts.case_insensitive);
+        assert!(opts.regex);
+        assert_eq!(opts.file_type.as_deref(), Some("rs"));
+        assert_eq!(opts.max_count, Some(10));
+        assert!(opts.word);
+        assert_eq!(opts.globs.len(), 2);
+    }
+
+    #[test]
+    fn test_index_status_structured() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("a.txt"), "hello\n").unwrap();
+        let xg = Xgrep::open_local(root).unwrap();
+        xg.build_index().unwrap();
+        let info = xg.index_status().unwrap();
+        assert_eq!(info.state, IndexState::Fresh);
+        assert_eq!(info.indexed_files, 1);
+        assert!(info.index_size_bytes > 0);
+        // Display preserves the human-readable format
+        let text = info.to_string();
+        assert!(text.contains("Status: fresh"));
+        assert!(text.contains("Indexed files: 1"));
+    }
+
+    #[test]
     fn test_pattern_has_uppercase_literal() {
         assert!(!pattern_has_uppercase("hello", false));
         assert!(pattern_has_uppercase("Hello", false));
@@ -1004,6 +1196,8 @@ mod tests {
         assert!(!pattern_has_uppercase(r"foo\d", true));
         // Escaped backslash followed by uppercase: \\ is literal backslash, D is uppercase
         assert!(pattern_has_uppercase(r"\\D", true));
+        // Trailing backslash is an incomplete escape and contributes no uppercase
+        assert!(!pattern_has_uppercase("foo\\", true));
     }
 
     /// Smart-case behavior verified at the library level via explicit flag:

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -112,6 +112,8 @@ pub struct SearchOptions {
     /// Check index freshness and use hybrid search for changed files.
     /// When false (default), uses existing index as-is for maximum speed.
     pub fresh: bool,
+    /// Match only at word boundaries (wraps the pattern in `\b(?:...)\b`)
+    pub word: bool,
 }
 
 /// Configuration for the search engine.
@@ -190,12 +192,32 @@ impl Xgrep {
         Ok(())
     }
 
+    /// Apply word-boundary wrapping. Returns the effective pattern and
+    /// whether it must be executed as a regex.
+    fn effective_pattern<'a>(
+        pattern: &'a str,
+        opts: &SearchOptions,
+    ) -> (std::borrow::Cow<'a, str>, bool) {
+        if opts.word {
+            let inner = if opts.regex {
+                pattern.to_string()
+            } else {
+                regex::escape(pattern)
+            };
+            (format!(r"\b(?:{})\b", inner).into(), true)
+        } else {
+            (pattern.into(), opts.regex)
+        }
+    }
+
     /// Execute a search. Auto-build, hybrid search, and git-changed-file search are handled internally.
     pub fn search(&self, pattern: &str, opts: &SearchOptions) -> Result<Vec<SearchResult>> {
+        let (pattern, regex) = Self::effective_pattern(pattern, opts);
+        let pattern = pattern.as_ref();
         let mut results = if opts.changed_only || opts.since.is_some() {
-            self.search_changed(pattern, opts)?
+            self.search_changed(pattern, regex, opts)?
         } else {
-            self.search_indexed(pattern, opts)?
+            self.search_indexed(pattern, regex, opts)?
         };
 
         // file_type filter
@@ -228,12 +250,17 @@ impl Xgrep {
     /// Index-based search. When `opts.fresh` is true, checks index freshness
     /// and uses hybrid search for changed files. When false (default), uses
     /// existing index as-is for maximum speed.
-    fn search_indexed(&self, pattern: &str, opts: &SearchOptions) -> Result<Vec<SearchResult>> {
+    fn search_indexed(
+        &self,
+        pattern: &str,
+        regex: bool,
+        opts: &SearchOptions,
+    ) -> Result<Vec<SearchResult>> {
         if !opts.fresh {
             // Fast path: use index as-is without freshness check
             if self.index_path.exists() {
                 let reader = index::reader::IndexReader::open(&self.index_path)?;
-                let results = if opts.regex {
+                let results = if regex {
                     search::search_regex(
                         &reader,
                         &self.root,
@@ -263,7 +290,7 @@ impl Xgrep {
         match status {
             index::updater::IndexStatus::Fresh => {
                 let reader = index::reader::IndexReader::open(&self.index_path)?;
-                if opts.regex {
+                if regex {
                     search::search_regex(
                         &reader,
                         &self.root,
@@ -285,7 +312,7 @@ impl Xgrep {
                 let reader = index::reader::IndexReader::open(&self.index_path)?;
 
                 // Search from index (results for changed files may be stale)
-                let mut index_results = if opts.regex {
+                let mut index_results = if regex {
                     search::search_regex(
                         &reader,
                         &self.root,
@@ -311,7 +338,7 @@ impl Xgrep {
                 index_results.retain(|r| !changed_set.contains(&r.file));
 
                 // Directly scan changed files
-                let direct_results = if opts.regex {
+                let direct_results = if regex {
                     search::search_files_regex(
                         &self.root,
                         &changed_files,
@@ -347,7 +374,7 @@ impl Xgrep {
                 }
 
                 let reader = index::reader::IndexReader::open(&self.index_path)?;
-                if opts.regex {
+                if regex {
                     search::search_regex(
                         &reader,
                         &self.root,
@@ -407,7 +434,9 @@ impl Xgrep {
         pattern: &str,
         opts: &SearchOptions,
     ) -> Result<Vec<SearchResult>> {
-        let mut results = if opts.regex {
+        let (pattern, regex) = Self::effective_pattern(pattern, opts);
+        let pattern = pattern.as_ref();
+        let mut results = if regex {
             search::search_files_regex(
                 &self.root,
                 files,
@@ -433,7 +462,12 @@ impl Xgrep {
     }
 
     /// Search only git-changed files. Returns error if not a git repository.
-    fn search_changed(&self, pattern: &str, opts: &SearchOptions) -> Result<Vec<SearchResult>> {
+    fn search_changed(
+        &self,
+        pattern: &str,
+        regex: bool,
+        opts: &SearchOptions,
+    ) -> Result<Vec<SearchResult>> {
         if !git::is_git_repo(&self.root) {
             return Err(XgrepError::NotGitRepo);
         }
@@ -448,7 +482,7 @@ impl Xgrep {
         files.sort();
         files.dedup();
 
-        if opts.regex {
+        if regex {
             search::search_files_regex(
                 &self.root,
                 &files,
@@ -958,6 +992,40 @@ mod tests {
 
     /// Smart-case behavior verified at the library level via explicit flag:
     /// the CLI maps (no -i, no -s, all-lowercase pattern) to case_insensitive=true.
+    #[test]
+    fn test_word_boundary_literal() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("a.txt"), "cat\nconcatenate\nthe cat, sat\n").unwrap();
+        let xg = Xgrep::open_local(root).unwrap();
+        xg.build_index().unwrap();
+        let opts = SearchOptions {
+            word: true,
+            ..Default::default()
+        };
+        let results = xg.search("cat", &opts).unwrap();
+        // Matches line 1 ("cat") and line 3 ("the cat, sat"), not "concatenate"
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.line != "concatenate"));
+    }
+
+    #[test]
+    fn test_word_boundary_with_regex_metachars_in_literal() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("a.txt"), "foo.bar baz\nfooxbar\n").unwrap();
+        let xg = Xgrep::open_local(root).unwrap();
+        xg.build_index().unwrap();
+        let opts = SearchOptions {
+            word: true,
+            ..Default::default()
+        };
+        // "." must be escaped: literal "foo.bar" must not match "fooxbar"
+        let results = xg.search("foo.bar", &opts).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].line.contains("foo.bar"));
+    }
+
     #[test]
     fn test_search_case_insensitive_finds_mixed_case() {
         let dir = tempfile::tempdir().unwrap();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,12 @@
 //!     println!("{}:{}: {}", r.file, r.line_number, r.line);
 //! }
 //! ```
+//!
+//! # Limitations
+//!
+//! Files smaller than 3 bytes contain no trigrams and are invisible to
+//! content search (they still appear in `--find` results). This is an
+//! intentional index design trade-off.
 
 pub(crate) mod candidates;
 pub mod error;
@@ -855,5 +861,46 @@ mod tests {
             "expected InvalidArgument, got {:?}",
             err
         );
+    }
+
+    /// Regression: a 2-char pattern occurring at EOF (no trailing byte) must be found.
+    /// Trigram "ab?" does not exist for the final "ab" in "xxab", but "xab" does.
+    /// A second file provides a non-empty prefix candidate set so the EOF case
+    /// cannot be masked by the full-scan fallback.
+    #[test]
+    fn test_two_char_pattern_at_eof() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        // No trailing newline: "ab" is the last 2 bytes (only "xab" trigram exists)
+        std::fs::write(root.join("tail.txt"), b"xxab").unwrap();
+        // Provides the "ab?" prefix trigram so the prefix lookup is non-empty
+        std::fs::write(root.join("other.txt"), b"abc def\n").unwrap();
+        let xg = Xgrep::open_local(root).unwrap();
+        xg.build_index().unwrap();
+        let results = xg.search("ab", &SearchOptions::default()).unwrap();
+        let files: Vec<&str> = results.iter().map(|r| r.file.as_str()).collect();
+        assert!(
+            files.iter().any(|f| f.ends_with("tail.txt")),
+            "2-char pattern at EOF must be found, got {:?}",
+            files
+        );
+        assert!(
+            files.iter().any(|f| f.ends_with("other.txt")),
+            "2-char pattern in prefix position must be found, got {:?}",
+            files
+        );
+    }
+
+    /// A 2-char pattern that exists nowhere must return no results
+    /// (and must not fall back to a full scan).
+    #[test]
+    fn test_two_char_pattern_no_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("a.txt"), b"hello world\n").unwrap();
+        let xg = Xgrep::open_local(root).unwrap();
+        xg.build_index().unwrap();
+        let results = xg.search("zq", &SearchOptions::default()).unwrap();
+        assert!(results.is_empty());
     }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -38,6 +38,14 @@ struct Cli {
     #[arg(short = 'C')]
     context: Option<usize>,
 
+    /// Lines of context after each match (overrides -C)
+    #[arg(short = 'A', long = "after-context", value_name = "NUM")]
+    after_context: Option<usize>,
+
+    /// Lines of context before each match (overrides -C)
+    #[arg(short = 'B', long = "before-context", value_name = "NUM")]
+    before_context: Option<usize>,
+
     /// Search only in git changed files (unstaged + staged)
     #[arg(long)]
     changed: bool,
@@ -449,17 +457,31 @@ fn run() -> Result<()> {
             } else {
                 let output_str = match cli.format.as_str() {
                     "llm" => {
-                        let ctx = cli.context.unwrap_or_else(|| {
+                        let base = cli.context.unwrap_or_else(|| {
                             std::env::var("XGREP_LLM_CONTEXT")
                                 .ok()
                                 .and_then(|v| v.parse().ok())
                                 .unwrap_or(3)
                         });
-                        output::format_llm(&results, &dir, ctx, None, use_absolute)?
+                        let before = cli.before_context.unwrap_or(base);
+                        let after = cli.after_context.unwrap_or(base);
+                        output::format_llm(&results, &dir, before, after, None, use_absolute)?
                     }
                     _ => {
-                        if let Some(ctx) = cli.context {
-                            output::format_default_context(&results, &dir, ctx, use_absolute)?
+                        let has_context = cli.context.is_some()
+                            || cli.before_context.is_some()
+                            || cli.after_context.is_some();
+                        if has_context {
+                            let base = cli.context.unwrap_or(0);
+                            let before = cli.before_context.unwrap_or(base);
+                            let after = cli.after_context.unwrap_or(base);
+                            output::format_default_context(
+                                &results,
+                                &dir,
+                                before,
+                                after,
+                                use_absolute,
+                            )?
                         } else if use_absolute {
                             let abs_results: Vec<_> = results
                                 .iter()

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -25,9 +25,14 @@ struct Cli {
     #[arg(long, default_value = "default")]
     format: String,
 
-    /// Case-insensitive search
+    /// Case-insensitive search (default: smart-case — insensitive unless
+    /// the pattern contains an uppercase letter)
     #[arg(short = 'i')]
     case_insensitive: bool,
+
+    /// Force case-sensitive search (disables smart-case)
+    #[arg(short = 's', long = "case-sensitive")]
+    case_sensitive: bool,
 
     /// Context lines (default: 3 for --format llm, none for default)
     #[arg(short = 'C')]
@@ -345,12 +350,20 @@ fn run() -> Result<()> {
                 return Ok(());
             }
 
+            let case_insensitive = if cli.case_insensitive {
+                true
+            } else if cli.case_sensitive {
+                false
+            } else {
+                !xgrep_search::pattern_has_uppercase(&pattern, cli.regex)
+            };
+
             let resolved = resolve_path(cli.path.as_deref())?;
             let (dir, results) = match resolved {
                 ResolvedPath::Dir(dir) => {
                     let xg = Xgrep::open(&dir)?;
                     let opts = SearchOptions {
-                        case_insensitive: cli.case_insensitive,
+                        case_insensitive,
                         regex: cli.regex,
                         file_type: cli.file_type,
                         max_count: cli.max_count,
@@ -366,7 +379,7 @@ fn run() -> Result<()> {
                     let rel_path = file.strip_prefix(&dir).unwrap_or(&file).to_path_buf();
                     let xg = Xgrep::open(&dir)?;
                     let opts = SearchOptions {
-                        case_insensitive: cli.case_insensitive,
+                        case_insensitive,
                         regex: cli.regex,
                         max_count: cli.max_count,
                         ..Default::default()

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -105,6 +105,10 @@ struct Cli {
     /// Exclude files matching path substring (can be repeated)
     #[arg(long, value_name = "PATTERN")]
     exclude: Vec<String>,
+
+    /// Include or exclude files by glob (prefix with ! to exclude; repeatable)
+    #[arg(short = 'g', long = "glob", value_name = "GLOB")]
+    globs: Vec<String>,
 }
 
 #[derive(Subcommand)]
@@ -384,6 +388,7 @@ fn run() -> Result<()> {
                         path_pattern: None,
                         fresh: cli.fresh,
                         word: cli.word_regexp,
+                        globs: cli.globs.clone(),
                     };
                     let results = xg.search(&pattern, &opts)?;
                     (dir, results)
@@ -396,6 +401,7 @@ fn run() -> Result<()> {
                         regex: cli.regex,
                         max_count: cli.max_count,
                         word: cli.word_regexp,
+                        globs: cli.globs.clone(),
                         ..Default::default()
                     };
                     let results = xg.search_files(&[rel_path], &pattern, &opts)?;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -58,6 +58,10 @@ struct Cli {
     #[arg(short = 'e')]
     regex: bool,
 
+    /// Only show matches surrounded by word boundaries
+    #[arg(short = 'w', long = "word-regexp")]
+    word_regexp: bool,
+
     /// Filter by file type (e.g., rs, py, js)
     #[arg(long = "type", short = 't')]
     file_type: Option<String>,
@@ -379,6 +383,7 @@ fn run() -> Result<()> {
                         since: cli.since,
                         path_pattern: None,
                         fresh: cli.fresh,
+                        word: cli.word_regexp,
                     };
                     let results = xg.search(&pattern, &opts)?;
                     (dir, results)
@@ -390,6 +395,7 @@ fn run() -> Result<()> {
                         case_insensitive,
                         regex: cli.regex,
                         max_count: cli.max_count,
+                        word: cli.word_regexp,
                         ..Default::default()
                     };
                     let results = xg.search_files(&[rel_path], &pattern, &opts)?;

--- a/rust/src/mcp_tools.rs
+++ b/rust/src/mcp_tools.rs
@@ -192,7 +192,14 @@ pub fn handle_search(xg: &Xgrep, params: &Value) -> (String, bool) {
             } else {
                 format!("Found {} matches in {} files\n\n", total, file_count)
             };
-            match output::format_llm(&results, xg.root(), context_lines, Some(max_tokens), false) {
+            match output::format_llm(
+                &results,
+                xg.root(),
+                context_lines,
+                context_lines,
+                Some(max_tokens),
+                false,
+            ) {
                 Ok(body) => (format!("{}{}", header, body), false),
                 Err(e) => (format!("Format error: {}", e), true),
             }
@@ -238,7 +245,7 @@ pub fn handle_find_definitions(xg: &Xgrep, params: &Value) -> (String, bool) {
                 symbol,
                 file_count
             );
-            match output::format_llm(&results, xg.root(), 3, None, false) {
+            match output::format_llm(&results, xg.root(), 3, 3, None, false) {
                 Ok(body) => (format!("{}{}", header, body), false),
                 Err(e) => (format!("Format error: {}", e), true),
             }

--- a/rust/src/mcp_tools.rs
+++ b/rust/src/mcp_tools.rs
@@ -102,7 +102,7 @@ pub fn tools_list() -> Vec<Value> {
         }),
         serde_json::json!({
             "name": "index_status",
-            "description": "Check the status of the search index. Returns a JSON object: state (\"fresh\", \"stale (N changed files)\", or \"missing\"), indexed_files (count), index_size_bytes, and index_path.",
+            "description": "Check the status of the search index. Returns a JSON object: state (\"fresh\", \"stale\", or \"missing\"), changed_files (count, present only when state is \"stale\"), indexed_files (count), index_size_bytes, and index_path.",
             "inputSchema": {
                 "type": "object",
                 "properties": {}
@@ -281,19 +281,20 @@ pub fn handle_index_status(xg: &Xgrep) -> (String, bool) {
     use crate::IndexState;
     match xg.index_status() {
         Ok(info) => {
-            let state = match info.state {
-                IndexState::Fresh => "fresh".to_string(),
-                IndexState::Stale { changed_files } => {
-                    format!("stale ({} changed files)", changed_files)
-                }
-                IndexState::Missing => "missing".to_string(),
+            let (state, changed_files) = match info.state {
+                IndexState::Fresh => ("fresh", None),
+                IndexState::Stale { changed_files } => ("stale", Some(changed_files)),
+                IndexState::Missing => ("missing", None),
             };
-            let json = serde_json::json!({
+            let mut json = serde_json::json!({
                 "state": state,
                 "indexed_files": info.indexed_files,
                 "index_size_bytes": info.index_size_bytes,
                 "index_path": info.index_path.to_string_lossy(),
             });
+            if let Some(c) = changed_files {
+                json["changed_files"] = c.into();
+            }
             (json.to_string(), false)
         }
         Err(e) => (format!("Status check error: {}", e), true),
@@ -470,6 +471,25 @@ mod tests {
         assert!(json["indexed_files"].as_u64().unwrap() >= 1);
         assert!(json["index_size_bytes"].as_u64().unwrap() > 0);
         assert!(json["index_path"].as_str().unwrap().contains("index"));
+        // Fresh index has no changed_files field.
+        assert!(json.get("changed_files").is_none());
+    }
+
+    #[test]
+    fn test_handle_index_status_stale_reports_changed_files() {
+        let (dir, xg) = setup_test_repo();
+        // Modify a tracked file after the index was built so the index goes stale.
+        fs::write(
+            dir.path().join("hello.rs"),
+            "fn hello() {\n    println!(\"changed\");\n}\n",
+        )
+        .unwrap();
+        let (output, is_error) = handle_index_status(&xg);
+        assert!(!is_error, "output was: {}", output);
+        let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+        // Agents branch on the bare state string, not prose.
+        assert_eq!(json["state"], "stale");
+        assert!(json["changed_files"].as_u64().unwrap() >= 1);
     }
 
     #[test]

--- a/rust/src/mcp_tools.rs
+++ b/rust/src/mcp_tools.rs
@@ -102,7 +102,7 @@ pub fn tools_list() -> Vec<Value> {
         }),
         serde_json::json!({
             "name": "index_status",
-            "description": "Check the status of the search index (freshness, file count).",
+            "description": "Check the status of the search index. Returns a JSON object: state (\"fresh\", \"stale (N changed files)\", or \"missing\"), indexed_files (count), index_size_bytes, and index_path.",
             "inputSchema": {
                 "type": "object",
                 "properties": {}
@@ -275,10 +275,27 @@ pub fn handle_build_index(xg: &Xgrep) -> (String, bool) {
     }
 }
 
-/// Handler for the `index_status` tool.
+/// Handler for the `index_status` tool. Returns a structured JSON object so
+/// agents can branch on the index state without parsing prose.
 pub fn handle_index_status(xg: &Xgrep) -> (String, bool) {
+    use crate::IndexState;
     match xg.index_status() {
-        Ok(msg) => (msg, false),
+        Ok(info) => {
+            let state = match info.state {
+                IndexState::Fresh => "fresh".to_string(),
+                IndexState::Stale { changed_files } => {
+                    format!("stale ({} changed files)", changed_files)
+                }
+                IndexState::Missing => "missing".to_string(),
+            };
+            let json = serde_json::json!({
+                "state": state,
+                "indexed_files": info.indexed_files,
+                "index_size_bytes": info.index_size_bytes,
+                "index_path": info.index_path.to_string_lossy(),
+            });
+            (json.to_string(), false)
+        }
         Err(e) => (format!("Status check error: {}", e), true),
     }
 }
@@ -441,6 +458,18 @@ mod tests {
         assert!(!is_error);
         assert!(output.contains("hello"));
         assert!(output.contains("definitions"));
+    }
+
+    #[test]
+    fn test_handle_index_status_structured_json() {
+        let (_dir, xg) = setup_test_repo();
+        let (output, is_error) = handle_index_status(&xg);
+        assert!(!is_error, "output was: {}", output);
+        let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(json["state"], "fresh");
+        assert!(json["indexed_files"].as_u64().unwrap() >= 1);
+        assert!(json["index_size_bytes"].as_u64().unwrap() > 0);
+        assert!(json["index_path"].as_str().unwrap().contains("index"));
     }
 
     #[test]

--- a/rust/src/output.rs
+++ b/rust/src/output.rs
@@ -64,7 +64,8 @@ fn estimate_tokens(text: &str) -> usize {
 pub fn format_llm(
     results: &[SearchResult],
     root: &Path,
-    context_lines: usize,
+    before_context: usize,
+    after_context: usize,
     max_tokens: Option<usize>,
     absolute_paths: bool,
 ) -> Result<String> {
@@ -104,8 +105,8 @@ pub fn format_llm(
         // Calculate context ranges and merge overlapping
         let mut ranges: Vec<(usize, usize)> = Vec::new();
         for &line_num in line_numbers {
-            let start = line_num.saturating_sub(context_lines).max(1);
-            let end = (line_num + context_lines).min(total_lines);
+            let start = line_num.saturating_sub(before_context).max(1);
+            let end = (line_num + after_context).min(total_lines);
 
             if let Some(last) = ranges.last_mut() {
                 if start <= last.1 + 1 {
@@ -167,7 +168,8 @@ pub fn format_llm(
 pub fn format_default_context(
     results: &[SearchResult],
     root: &Path,
-    context_lines: usize,
+    before_context: usize,
+    after_context: usize,
     absolute_paths: bool,
 ) -> Result<String> {
     if results.is_empty() {
@@ -195,8 +197,8 @@ pub fn format_default_context(
 
         let mut ranges: Vec<(usize, usize, Vec<usize>)> = Vec::new();
         for &ln in line_numbers {
-            let start = ln.saturating_sub(context_lines).max(1);
-            let end = (ln + context_lines).min(total_lines);
+            let start = ln.saturating_sub(before_context).max(1);
+            let end = (ln + after_context).min(total_lines);
             if let Some(last) = ranges.last_mut() {
                 if start <= last.1 + 1 {
                     last.1 = last.1.max(end);
@@ -329,7 +331,7 @@ mod tests {
             line_number: 3,
             line: "fn hello() {}".to_string(),
         }];
-        let output = format_llm(&results, root, 2, None, false).unwrap();
+        let output = format_llm(&results, root, 2, 2, None, false).unwrap();
         assert!(output.contains("## test.rs:"));
         assert!(output.contains("```rust"));
         assert!(output.contains("fn hello() {}"));
@@ -354,7 +356,7 @@ mod tests {
                 line: "l5".to_string(),
             },
         ];
-        let output = format_llm(&results, root, 1, None, false).unwrap();
+        let output = format_llm(&results, root, 1, 1, None, false).unwrap();
         let block_count = output.matches("```rust").count();
         assert_eq!(block_count, 1); // merged into one block
     }
@@ -373,7 +375,7 @@ mod tests {
             line_number: 3,
             line: "match_line".to_string(),
         }];
-        let output = format_default_context(&results, root, 1, false).unwrap();
+        let output = format_default_context(&results, root, 1, 1, false).unwrap();
         assert!(output.contains("test.rs-2-line2")); // context line uses -
         assert!(output.contains("test.rs:3:match_line")); // match line uses :
         assert!(output.contains("test.rs-4-line4")); // context line uses -
@@ -388,7 +390,7 @@ mod tests {
     #[test]
     fn test_format_llm_empty() {
         let dir = tempdir().unwrap();
-        let output = format_llm(&[], dir.path(), 3, None, false).unwrap();
+        let output = format_llm(&[], dir.path(), 3, 3, None, false).unwrap();
         assert_eq!(output, "");
     }
 
@@ -402,7 +404,7 @@ mod tests {
             line_number: 2,
             line: "\techo hello".to_string(),
         }];
-        let output = format_llm(&results, root, 1, None, false).unwrap();
+        let output = format_llm(&results, root, 1, 1, None, false).unwrap();
         // No extension = empty language
         assert!(output.contains("```\n")); // no language after ```
         assert!(output.contains("echo hello"));
@@ -418,7 +420,7 @@ mod tests {
             line_number: 3,
             line: "line3".to_string(),
         }];
-        let output = format_llm(&results, root, 0, None, false).unwrap();
+        let output = format_llm(&results, root, 0, 0, None, false).unwrap();
         assert!(output.contains("line3"));
         assert!(!output.contains("line2")); // no context
         assert!(!output.contains("line4"));
@@ -427,7 +429,7 @@ mod tests {
     #[test]
     fn test_format_default_context_empty() {
         let dir = tempdir().unwrap();
-        let output = format_default_context(&[], dir.path(), 3, false).unwrap();
+        let output = format_default_context(&[], dir.path(), 3, 3, false).unwrap();
         assert_eq!(output, "");
     }
 
@@ -453,7 +455,7 @@ mod tests {
         }
 
         // With very low token limit, should truncate after first file
-        let output = format_llm(&results, root, 1, Some(50), false).unwrap();
+        let output = format_llm(&results, root, 1, 1, Some(50), false).unwrap();
         assert!(output.contains("truncated"));
         assert!(output.contains("more matches"));
         assert!(output.contains("more files"));
@@ -499,8 +501,48 @@ mod tests {
             line: "line2".to_string(),
         }];
 
-        let output = format_llm(&results, root, 1, None, false).unwrap();
+        let output = format_llm(&results, root, 1, 1, None, false).unwrap();
         assert!(!output.contains("truncated"));
         assert!(output.contains("line2"));
+    }
+
+    #[test]
+    fn test_format_default_context_asymmetric() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::write(
+            root.join("test.rs"),
+            "line1\nline2\nmatch_line\nline4\nline5",
+        )
+        .unwrap();
+        let results = vec![SearchResult {
+            file: "test.rs".to_string(),
+            line_number: 3,
+            line: "match_line".to_string(),
+        }];
+        // before=0, after=2: no lines before, two lines after
+        let output = format_default_context(&results, root, 0, 2, false).unwrap();
+        assert!(!output.contains("line2"));
+        assert!(output.contains("test.rs:3:match_line"));
+        assert!(output.contains("test.rs-4-line4"));
+        assert!(output.contains("test.rs-5-line5"));
+    }
+
+    #[test]
+    fn test_format_llm_asymmetric() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("test.rs"), "l1\nl2\nl3\nl4\nl5").unwrap();
+        let results = vec![SearchResult {
+            file: "test.rs".to_string(),
+            line_number: 3,
+            line: "l3".to_string(),
+        }];
+        // before=2, after=0
+        let output = format_llm(&results, root, 2, 0, None, false).unwrap();
+        assert!(output.contains("l1"));
+        assert!(output.contains("l2"));
+        assert!(output.contains("l3"));
+        assert!(!output.contains("l4"));
     }
 }

--- a/rust/src/output.rs
+++ b/rust/src/output.rs
@@ -545,4 +545,29 @@ mod tests {
         assert!(output.contains("l3"));
         assert!(!output.contains("l4"));
     }
+
+    #[test]
+    fn test_format_llm_asymmetric_merge() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("test.rs"), "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8").unwrap();
+        let results = vec![
+            SearchResult {
+                file: "test.rs".to_string(),
+                line_number: 2,
+                line: "l2".to_string(),
+            },
+            SearchResult {
+                file: "test.rs".to_string(),
+                line_number: 5,
+                line: "l5".to_string(),
+            },
+        ];
+        // before=0, after=3: match at 2 covers 2-5, match at 5 covers 5-8 -> one merged block 2-8
+        let output = format_llm(&results, root, 0, 3, None, false).unwrap();
+        let block_count = output.matches("```rust").count();
+        assert_eq!(block_count, 1, "overlapping asymmetric ranges must merge");
+        assert!(output.contains("## test.rs:2-8"));
+        assert!(!output.contains("l1"));
+    }
 }

--- a/rust/tests/mcp_integration_test.rs
+++ b/rust/tests/mcp_integration_test.rs
@@ -129,12 +129,15 @@ fn test_mcp_build_index() {
         .unwrap();
     assert!(text.contains("Index built"));
 
-    // index_status
+    // index_status returns structured JSON
     assert_eq!(responses[2]["id"], 3);
     let status_text = responses[2]["result"]["content"][0]["text"]
         .as_str()
         .unwrap();
-    assert!(status_text.contains("Index path:"));
+    let status: serde_json::Value = serde_json::from_str(status_text).unwrap();
+    assert!(status["state"].as_str().unwrap().contains("fresh"));
+    assert!(status["indexed_files"].as_u64().unwrap() >= 1);
+    assert!(status["index_path"].as_str().unwrap().contains("index"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

ripgrep-compatible search UX and reduced onboarding friction, plus an AI-friendly library/MCP API. Brings `xg` closer to a drop-in habit for engineers used to ripgrep, and makes the structured API easier to drive from agents.

## Changes

**Search UX (ripgrep parity)**
- Smart-case by default — all-lowercase patterns match case-insensitively; any uppercase makes it case-sensitive. `-s`/`--case-sensitive` overrides (priority `-i` > `-s` > smart-case)
- `-A`/`-B` asymmetric context lines (in addition to `-C`)
- `-w`/`--word-regexp` word-boundary matching
- `-g`/`--glob` include/exclude path filters (`!` prefix to exclude, repeatable)

**Correctness**
- Fix 2-char pattern candidate resolution via prefix+suffix trigram union (previously could miss matches on 2-char queries)
- Honor `-g` on the explicit-file search path; reject empty globs

**Library / MCP API**
- `SearchOptions` fluent builder (no exhaustive struct literal needed)
- Structured `IndexStatusInfo` / `IndexState` return type (branch on freshness without parsing prose)
- MCP `index_status` emits bare `state` + optional `changed_files` (consistent with the napi binding)
- napi bindings aligned with the new API (`word`/`globs` options, structured `indexStatus`)
- New `docs/agents.md` agent-oriented usage guide

## Breaking changes

- Search is now smart-case by default (was case-sensitive). Use `-s` to restore always-case-sensitive behavior
- `index_status()` returns `IndexStatusInfo` instead of `String`
- `SearchOptions` gains `word` / `globs` fields

## Test plan

- `cargo test` in `rust/` — all tests pass (incl. MCP integration, CLI exit-code, find tests)
- napi: `npm test` in `npm/` passes (structured indexStatus, word-boundary, glob-filter cases)
- Benchmarks re-measured on M4/32GB: grep search small 1.5-1.7x / medium 1.2-1.6x vs ripgrep; `--find` next.js `*.ts` 9x / `config` 15x vs fd. Direct v0.3.0 vs v0.4.0 comparison shows no regression (content 1.20x, `--find` 1.04x). README/benchmarks.md updated to reproducible medians
- Code quality review: 75/100 (+7 from v0.3.0's 68), no release blocker
