### PR TITLE
fix: GitHub Actions Node24対応、ハウスキーピング、Arc<str>移行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -63,7 +63,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -87,7 +87,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -125,7 +125,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -151,7 +151,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@ff9b7e97f1c15b93257ad9a20e43c84dc3eef47b # 1.85.0
@@ -170,14 +170,14 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: npm
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       - name: Install dependencies
@@ -210,7 +210,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -223,7 +223,7 @@ jobs:
         working-directory: rust
         run: cargo build --release --target ${{ matrix.target }}
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact }}
           path: rust/target/${{ matrix.target }}/release/xg

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -29,7 +29,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -57,7 +57,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -70,7 +70,7 @@ jobs:
         run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashes-${{ matrix.target }}
           path: rust/fuzz/artifacts/${{ matrix.target }}/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - id: tag
@@ -73,7 +73,7 @@ jobs:
             artifact: xg-x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -129,7 +129,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -167,13 +167,13 @@ jobs:
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target }}
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0.4.0
         with:
           node-version: 20
       - name: Install dependencies
@@ -194,7 +194,7 @@ jobs:
         working-directory: npm
         run: node __test__/index.mjs
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bindings-${{ matrix.target }}
           path: npm/xgrep.*.node
@@ -209,17 +209,17 @@ jobs:
       contents: read
       id-token: write # OIDC for npm trusted publishing
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
       - name: Ensure npm supports trusted publishing (OIDC)
         run: npm install -g npm@latest
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: npm/artifacts
       - name: Move binaries

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Run analysis

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -107,7 +107,7 @@ Add the crate and drive it directly. Options use a fluent builder, so you never
 need an exhaustive struct literal:
 
 ```rust
-use xgrep_search::{Xgrep, SearchOptions, IndexState};
+use xgrep_search::{Xgrep, SearchOptions};
 
 let xg = Xgrep::open(".")?;
 xg.build_index()?;

--- a/npm/src/lib.rs
+++ b/npm/src/lib.rs
@@ -161,7 +161,7 @@ fn to_js_status(info: xgrep_search::IndexStatusInfo) -> IndexStatus {
 
 fn to_js_result(r: xgrep_search::search::SearchResult) -> SearchResult {
     SearchResult {
-        file: r.file,
+        file: r.file.to_string(),
         line_number: r.line_number as u32,
         line: r.line,
     }

--- a/rust/src/git.rs
+++ b/rust/src/git.rs
@@ -14,7 +14,7 @@ pub fn is_git_repo(root: &Path) -> bool {
 }
 
 /// Get the git repository root directory.
-fn git_toplevel(root: &Path) -> Option<PathBuf> {
+pub(crate) fn git_toplevel(root: &Path) -> Option<PathBuf> {
     let output = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(root)

--- a/rust/src/hints.rs
+++ b/rust/src/hints.rs
@@ -202,9 +202,17 @@ fn is_quantifier(s: &str) -> bool {
 
 /// `(?:...)`, `(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)`
 fn detect_lookaround(pattern: &str) -> Option<String> {
+    let bytes = pattern.as_bytes();
     for prefix in &["(?:", "(?=", "(?!", "(?<=", "(?<!"] {
-        if pattern.contains(prefix) {
-            return Some(prefix.to_string());
+        let mut start = 0;
+        while let Some(rel_pos) = pattern[start..].find(prefix) {
+            let pos = start + rel_pos;
+            let escaped =
+                pos > 0 && bytes[pos - 1] == b'\\' && !is_escaped_backslash(bytes, pos - 1);
+            if !escaped {
+                return Some(prefix.to_string());
+            }
+            start = pos + 1;
         }
     }
     None
@@ -288,6 +296,10 @@ mod tests {
         assert!(detect_regex_hint("(?!baz)").is_some());
         assert!(detect_regex_hint("(?<=x)").is_some());
         assert!(detect_regex_hint("(?<!y)").is_some());
+        // \(?:foo) — '(' is escaped by unescaped '\', not a lookaround
+        assert!(detect_lookaround(r"\(?:foo)").is_none());
+        // \\(?:foo) — '\\' is an escaped backslash (literal), '(?:' IS a lookaround
+        assert!(detect_lookaround(r"\\(?:foo)").is_some());
     }
 
     #[test]

--- a/rust/src/index/format.rs
+++ b/rust/src/index/format.rs
@@ -68,9 +68,9 @@ pub struct Header {
 /// Trigram Table entry: 16 bytes
 /// trigram(3) + padding(1) + posting_offset(8) + posting_len(4) = 16
 ///
-/// WARNING: Do NOT use `unsafe { ptr::read_unaligned(... as *const TrigramEntry) }` or similar
-/// pointer casts on this struct. Always use `to_bytes()` for serialization.
-/// The packed repr exists only to define the exact byte layout.
+/// `packed` is required here: without it `repr(C)` inserts 4 bytes of alignment
+/// padding before `posting_offset`, making `SIZE` 24 instead of 16.
+/// All access goes through `to_bytes()` — never cast a pointer to this struct.
 #[repr(C, packed)]
 #[derive(Debug, Clone, Copy)]
 pub struct TrigramEntry {
@@ -83,9 +83,9 @@ pub struct TrigramEntry {
 /// File Table entry: 28 bytes
 /// path_offset(4) + mtime(8) + size(8) + content_hash(8) = 28
 ///
-/// WARNING: Do NOT use `unsafe { ptr::read_unaligned(... as *const FileEntry) }` or similar
-/// pointer casts on this struct. Always use `to_bytes()` for serialization.
-/// The packed repr exists only to define the exact byte layout.
+/// `packed` is required here: without it `repr(C)` inserts 4 bytes of alignment
+/// padding after `path_offset`, making `SIZE` 32 instead of 28.
+/// All access goes through `to_bytes()` — never cast a pointer to this struct.
 #[repr(C, packed)]
 #[derive(Debug, Clone, Copy)]
 pub struct FileEntry {

--- a/rust/src/index/updater.rs
+++ b/rust/src/index/updater.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::Result;
+use crate::git::git_toplevel;
 use ignore::WalkBuilder;
 
 /// Index freshness check result.
@@ -38,22 +39,6 @@ impl IndexMeta {
         let content = commit_hash.unwrap_or("");
         fs::write(&meta_path, content)?;
         Ok(())
-    }
-}
-
-/// Get the git repository root directory (via `git rev-parse --show-toplevel`).
-fn git_toplevel(root: &Path) -> Option<PathBuf> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .current_dir(root)
-        .output()
-        .ok()?;
-    if output.status.success() {
-        Some(PathBuf::from(
-            String::from_utf8_lossy(&output.stdout).trim(),
-        ))
-    } else {
-        None
     }
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -196,6 +196,18 @@ impl SearchOptions {
         self.fresh = value;
         self
     }
+
+    /// Only search files changed within a time duration (e.g. `"1h"`, `"2d"`, `"3.commits"`).
+    pub fn with_since(mut self, since: impl Into<String>) -> Self {
+        self.since = Some(since.into());
+        self
+    }
+
+    /// Filter results by path substring match (e.g. `"src/auth"`, `"tests/"`).
+    pub fn with_path_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.path_pattern = Some(pattern.into());
+        self
+    }
 }
 
 /// Configuration for the search engine.
@@ -381,7 +393,7 @@ impl Xgrep {
         if let Some(ref ft) = opts.file_type {
             if let Some(exts) = filetype::extensions_for_type(ft) {
                 results.retain(|r| {
-                    Path::new(&r.file)
+                    Path::new(&*r.file)
                         .extension()
                         .and_then(|e| e.to_str())
                         .is_some_and(|e| exts.contains(&e))
@@ -498,7 +510,7 @@ impl Xgrep {
                     .iter()
                     .map(|p| p.to_string_lossy().to_string())
                     .collect();
-                index_results.retain(|r| !changed_set.contains(&r.file));
+                index_results.retain(|r| !changed_set.contains(r.file.as_ref()));
 
                 // Directly scan changed files
                 let direct_results = if regex {
@@ -1118,7 +1130,7 @@ mod tests {
         let xg = Xgrep::open_local(root).unwrap();
         xg.build_index().unwrap();
         let results = xg.search("ab", &SearchOptions::default()).unwrap();
-        let files: Vec<&str> = results.iter().map(|r| r.file.as_str()).collect();
+        let files: Vec<&str> = results.iter().map(|r| r.file.as_ref()).collect();
         assert!(
             files.iter().any(|f| f.ends_with("tail.txt")),
             "2-char pattern at EOF must be found, got {:?}",

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -457,7 +457,7 @@ fn run() -> Result<()> {
                     let abs_results: Vec<_> = results
                         .iter()
                         .map(|r| xgrep_search::SearchResult {
-                            file: make_path(&r.file),
+                            file: make_path(&r.file).into(),
                             line_number: r.line_number,
                             line: r.line.clone(),
                         })
@@ -498,7 +498,7 @@ fn run() -> Result<()> {
                             let abs_results: Vec<_> = results
                                 .iter()
                                 .map(|r| xgrep_search::SearchResult {
-                                    file: make_path(&r.file),
+                                    file: make_path(&r.file).into(),
                                     line_number: r.line_number,
                                     line: r.line.clone(),
                                 })

--- a/rust/src/output.rs
+++ b/rust/src/output.rs
@@ -44,7 +44,7 @@ pub fn format_json(results: &[SearchResult]) -> String {
         .iter()
         .map(|r| {
             serde_json::json!({
-                "file": r.file,
+                "file": &*r.file,
                 "line_number": r.line_number,
                 "line": r.line
             })
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     fn test_format_json() {
         let results = vec![SearchResult {
-            file: "src/main.rs".to_string(),
+            file: "src/main.rs".into(),
             line_number: 42,
             line: "fn handle_auth() {}".to_string(),
         }];
@@ -259,12 +259,12 @@ mod tests {
     fn test_format_json_multiple() {
         let results = vec![
             SearchResult {
-                file: "a.rs".to_string(),
+                file: "a.rs".into(),
                 line_number: 1,
                 line: "foo".to_string(),
             },
             SearchResult {
-                file: "b.rs".to_string(),
+                file: "b.rs".into(),
                 line_number: 2,
                 line: "bar".to_string(),
             },
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     fn test_format_default() {
         let results = vec![SearchResult {
-            file: "src/main.rs".to_string(),
+            file: "src/main.rs".into(),
             line_number: 42,
             line: "    fn handle_auth() {}".to_string(),
         }];
@@ -290,12 +290,12 @@ mod tests {
     fn test_format_default_multiple() {
         let results = vec![
             SearchResult {
-                file: "a.rs".to_string(),
+                file: "a.rs".into(),
                 line_number: 1,
                 line: "foo".to_string(),
             },
             SearchResult {
-                file: "b.rs".to_string(),
+                file: "b.rs".into(),
                 line_number: 10,
                 line: "bar".to_string(),
             },
@@ -327,7 +327,7 @@ mod tests {
         )
         .unwrap();
         let results = vec![SearchResult {
-            file: "test.rs".to_string(),
+            file: "test.rs".into(),
             line_number: 3,
             line: "fn hello() {}".to_string(),
         }];
@@ -346,12 +346,12 @@ mod tests {
         fs::write(root.join("test.rs"), "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8").unwrap();
         let results = vec![
             SearchResult {
-                file: "test.rs".to_string(),
+                file: "test.rs".into(),
                 line_number: 3,
                 line: "l3".to_string(),
             },
             SearchResult {
-                file: "test.rs".to_string(),
+                file: "test.rs".into(),
                 line_number: 5,
                 line: "l5".to_string(),
             },
@@ -371,7 +371,7 @@ mod tests {
         )
         .unwrap();
         let results = vec![SearchResult {
-            file: "test.rs".to_string(),
+            file: "test.rs".into(),
             line_number: 3,
             line: "match_line".to_string(),
         }];
@@ -400,7 +400,7 @@ mod tests {
         let root = dir.path();
         fs::write(root.join("Makefile"), "all:\n\techo hello\n\techo done").unwrap();
         let results = vec![SearchResult {
-            file: "Makefile".to_string(),
+            file: "Makefile".into(),
             line_number: 2,
             line: "\techo hello".to_string(),
         }];
@@ -416,7 +416,7 @@ mod tests {
         let root = dir.path();
         fs::write(root.join("test.rs"), "line1\nline2\nline3\nline4\nline5").unwrap();
         let results = vec![SearchResult {
-            file: "test.rs".to_string(),
+            file: "test.rs".into(),
             line_number: 3,
             line: "line3".to_string(),
         }];
@@ -447,7 +447,7 @@ mod tests {
         for file in &["a.rs", "b.rs", "c.rs"] {
             for i in (2..=10).step_by(2) {
                 results.push(SearchResult {
-                    file: file.to_string(),
+                    file: (*file).into(),
                     line_number: i,
                     line: format!("line number {}", i),
                 });
@@ -496,7 +496,7 @@ mod tests {
         fs::write(root.join("a.rs"), "line1\nline2\nline3").unwrap();
 
         let results = vec![SearchResult {
-            file: "a.rs".to_string(),
+            file: "a.rs".into(),
             line_number: 2,
             line: "line2".to_string(),
         }];
@@ -516,7 +516,7 @@ mod tests {
         )
         .unwrap();
         let results = vec![SearchResult {
-            file: "test.rs".to_string(),
+            file: "test.rs".into(),
             line_number: 3,
             line: "match_line".to_string(),
         }];
@@ -534,7 +534,7 @@ mod tests {
         let root = dir.path();
         fs::write(root.join("test.rs"), "l1\nl2\nl3\nl4\nl5").unwrap();
         let results = vec![SearchResult {
-            file: "test.rs".to_string(),
+            file: "test.rs".into(),
             line_number: 3,
             line: "l3".to_string(),
         }];
@@ -553,12 +553,12 @@ mod tests {
         fs::write(root.join("test.rs"), "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8").unwrap();
         let results = vec![
             SearchResult {
-                file: "test.rs".to_string(),
+                file: "test.rs".into(),
                 line_number: 2,
                 line: "l2".to_string(),
             },
             SearchResult {
-                file: "test.rs".to_string(),
+                file: "test.rs".into(),
                 line_number: 5,
                 line: "l5".to_string(),
             },

--- a/rust/src/search.rs
+++ b/rust/src/search.rs
@@ -8,6 +8,7 @@ use regex::RegexBuilder;
 use std::borrow::Cow;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// ASCII-only case-insensitive contains check (for testing).
 /// Uses memmem::Finder internally to verify with the same algorithm as production code.
@@ -53,7 +54,7 @@ fn line_start(line_offsets: &[usize], line_num: usize) -> usize {
 
 #[derive(Debug, Clone)]
 pub struct SearchResult {
-    pub file: String,
+    pub file: Arc<str>,
     pub line_number: usize,
     pub line: String,
 }
@@ -81,6 +82,7 @@ impl Matcher for LiteralMatcher {
         }
 
         // Only build line offsets when we know there's at least one match
+        let file: Arc<str> = Arc::from(rel_path);
         let line_offsets = build_line_offsets(content);
         let mut results = Vec::new();
         let mut pos = 0;
@@ -96,7 +98,7 @@ impl Matcher for LiteralMatcher {
             let line = std::str::from_utf8(&content[ls..line_end]).unwrap_or("<binary>");
 
             results.push(SearchResult {
-                file: rel_path.to_string(),
+                file: Arc::clone(&file),
                 line_number: line_num,
                 line: line.to_string(),
             });
@@ -131,6 +133,7 @@ impl Matcher for CaseInsensitiveMatcher {
 
         // Match found — scan lowered content line by line to identify matching lines,
         // but return the original (non-lowered) line text.
+        let file: Arc<str> = Arc::from(rel_path);
         let mut results = Vec::new();
         let mut line_num = 0usize;
         let mut start = 0usize;
@@ -146,7 +149,7 @@ impl Matcher for CaseInsensitiveMatcher {
                 let original_line = &content[start..line_end];
                 let line = std::str::from_utf8(original_line).unwrap_or("<binary>");
                 results.push(SearchResult {
-                    file: rel_path.to_string(),
+                    file: Arc::clone(&file),
                     line_number: line_num,
                     line: line.to_string(),
                 });
@@ -176,11 +179,12 @@ impl Matcher for RegexMatcher {
             return vec![];
         }
 
+        let file: Arc<str> = Arc::from(rel_path);
         let mut results = Vec::new();
         for (i, line) in content_str.lines().enumerate() {
             if self.re.is_match(line) {
                 results.push(SearchResult {
-                    file: rel_path.to_string(),
+                    file: Arc::clone(&file),
                     line_number: i + 1,
                     line: line.to_string(),
                 });
@@ -767,7 +771,7 @@ mod tests {
         let reader = IndexReader::open(&index_path).unwrap();
         let results = search(&reader, root, "hello world", true, false).unwrap();
         assert_eq!(results.len(), 3);
-        let mut files: Vec<&str> = results.iter().map(|r| r.file.as_str()).collect();
+        let mut files: Vec<&str> = results.iter().map(|r| r.file.as_ref()).collect();
         files.sort();
         assert!(files.iter().any(|f| f.contains("upper.txt")));
         assert!(files.iter().any(|f| f.contains("lower.txt")));

--- a/rust/tests/api_test.rs
+++ b/rust/tests/api_test.rs
@@ -139,7 +139,7 @@ fn test_search_changed_requires_git() {
 #[test]
 fn test_search_result_debug_clone() {
     let r = xgrep_search::SearchResult {
-        file: "a.rs".to_string(),
+        file: std::sync::Arc::from("a.rs"),
         line_number: 1,
         line: "hello".to_string(),
     };


### PR DESCRIPTION
## 変更内容

### #42 GitHub Actions Node20 → Node24 対応
- `actions/checkout`: v4 (SHA: `34e114876b...`) → v6.0.3 (`df4cb1c069...`)
- `actions/setup-node`: v4 → v6.4.0 (`48b55a011b...`)
- `actions/upload-artifact`: v4 → v7.0.1 (`043fb46d1a...`)
- `actions/download-artifact`: v4 → v7.0.0 (`37930b1c2a...`)
- Node20 ランナーは 2026-09-16 に完全削除予定のため対応

### #41 ハウスキーピング
- `git_toplevel` を `rust/src/git.rs` に一本化し `updater.rs` の重複実装を削除（空文字列チェックを持つ版に統一）
- `detect_lookaround`: `\(?:foo)` を誤検知しないよう `is_escaped_backslash()` によるエスケープチェックを追加
- `format.rs`: `repr(C, packed)` の WARNING コメントを改善（packed が必要な理由 = u64 の 8-byte アライメントで SIZE が 16 → 24 bytes になること）
- `docs/agents.md`: 未使用の `IndexState` インポートを削除

### #38 SearchOptions builder 補完 + `SearchResult::file` を `Arc<str>` に変更
- `SearchResult::file: String` → `Arc<str>`（同一ファイルの全マッチを1アロケーションで共有）
- `SearchOptions` builder を補完: `with_since()`, `with_path_pattern()` を追加
- `Arc<str>` への移行に伴う修正箇所: `&*r.file`（json!/Path::new）、`r.file.as_ref()`（HashSet contains/Vec collect）、`.into()`（Arc from String）

## テスト計画
- [ ] `cargo test` がパスすること（git state 依存テストは除く）
- [ ] `cargo clippy` が警告なしであること
- [ ] GitHub Actions の各ワークフローが Node24 で正常動作すること
- [ ] `xg` コマンドで `with_since`, `with_path_pattern` が機能すること

Closes #42
Closes #41
Closes #38