### PR TITLE
fix: release-please-action を v5.0.0（Node.js 24対応）にバンプ

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
release-please-action v4.4.1 が Node.js 20 を使用しており、2026-06-16 から Node.js 24 が強制されるため動作しなかった。v5.0.0（Node.js 24 ネイティブ）にバンプ。

## マージ前に必要な手動設定

Settings → Actions → General → Workflow permissions → **"Allow GitHub Actions to create and approve pull requests"** を有効にすること。

この設定なしでは Release Please が Release PR を作成できず失敗する。