### PR TITLE
fix: release.yml に workflow_dispatch を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v[0-9]+.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.4.2)"
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,8 +26,12 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          ref: ${{ inputs.tag || github.ref }}
       - id: tag
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [ -z "$TAG" ]; then TAG="${GITHUB_REF#refs/tags/}"; fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - id: version
         name: Extract and verify version
         env:


### PR DESCRIPTION
Release Please が GITHUB_TOKEN でタグを作成した際、GitHub の仕様上 release.yml が自動トリガーされない問題への対処。\n\n`gh workflow run release.yml --field tag=vX.Y.Z` で手動トリガー可能になる。