### PR TITLE
feat: release-please.yml にビルド・publish を統合して完全自動化

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,13 +11,241 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  build-release:
+    name: Build (${{ matrix.target }})
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: xg-x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: xg-aarch64-unknown-linux-gnu
+            cross: true
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: xg-aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact: xg-x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: xg-x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ needs.release-please.outputs.tag_name }}
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          workspaces: rust
+      - name: Install cross-compilation tools
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Build release
+        working-directory: rust
+        run: cargo build --release --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      - name: Package (unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          cd rust/target/${{ matrix.target }}/release
+          tar czf ${{ matrix.artifact }}.tar.gz xg
+          mv ${{ matrix.artifact }}.tar.gz ../../../../
+      - name: Package (windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          cd rust/target/${{ matrix.target }}/release
+          Compress-Archive -Path xg.exe -DestinationPath ${{ matrix.artifact }}.zip
+          Move-Item ${{ matrix.artifact }}.zip ../../../../
+      - name: Upload to release (unix)
+        if: matrix.os != 'windows-latest'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
+          ARTIFACT: ${{ matrix.artifact }}
+        run: gh release upload "$RELEASE_TAG" "${ARTIFACT}.tar.gz" --clobber --repo "${{ github.repository }}"
+      - name: Upload to release (windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
+          ARTIFACT: ${{ matrix.artifact }}
+        run: gh release upload "$env:RELEASE_TAG" "$env:ARTIFACT.zip" --clobber --repo "${{ github.repository }}"
+
+  publish-crate:
+    name: Publish to crates.io
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ needs.release-please.outputs.tag_name }}
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
+      - name: Publish (idempotent)
+        working-directory: rust
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if cargo search xgrep-search --limit 1 2>/dev/null | grep -q "\"$CARGO_VERSION\""; then
+            echo "::warning::xgrep-search $CARGO_VERSION already published on crates.io — skipping. If the tag was moved to a new commit, bump the version instead of re-tagging."
+          else
+            cargo publish --allow-dirty
+          fi
+
+  build-npm:
+    name: Build npm (${{ matrix.target }})
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ needs.release-please.outputs.tag_name }}
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+      - name: Install dependencies
+        working-directory: npm
+        run: npm ci
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Build native module
+        working-directory: npm
+        run: npx napi build --release --platform --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      - name: Test
+        if: matrix.target == 'x86_64-unknown-linux-gnu' || contains(matrix.os, 'macos') && matrix.target == 'aarch64-apple-darwin'
+        working-directory: npm
+        run: node __test__/index.mjs
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bindings-${{ matrix.target }}
+          path: npm/xgrep.*.node
+          if-no-files-found: error
+
+  publish-npm:
+    name: Publish to npm
+    needs: [release-please, build-npm]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ needs.release-please.outputs.tag_name }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+      - name: Download all artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: npm/artifacts
+      - name: Move binaries
+        working-directory: npm
+        run: |
+          for dir in artifacts/bindings-*/; do
+            cp "$dir"/*.node . 2>/dev/null || true
+          done
+          ls -la *.node
+      - name: Sync version from Cargo.toml
+        working-directory: npm
+        env:
+          RELEASE_VERSION: ${{ needs.release-please.outputs.version }}
+        run: npm version "$RELEASE_VERSION" --no-git-tag-version
+      - name: Install dependencies
+        working-directory: npm
+        run: npm ci
+      - name: Publish (idempotent, OIDC trusted publishing)
+        working-directory: npm
+        run: |
+          RELEASE_VERSION="${{ needs.release-please.outputs.version }}"
+          if npm view xgrep@"$RELEASE_VERSION" version 2>/dev/null | grep -q "$RELEASE_VERSION"; then
+            echo "::warning::xgrep@$RELEASE_VERSION already published on npm — skipping. If the tag was moved to a new commit, bump the version instead of re-tagging."
+          else
+            npm publish --access public
+          fi
+
+  publish-release:
+    name: Publish Release
+    needs: [release-please, build-release]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Mark release as non-draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --repo "${{ github.repository }}"


### PR DESCRIPTION
## 変更内容

`release-please.yml` に全ての publish ジョブを統合。

**これまでの問題:**
Release Please が `GITHUB_TOKEN` でタグを作成すると、GitHub のセキュリティ仕様上 `release.yml` がトリガーされない。手動で `gh workflow run` する必要があった。

**解決策:**
`release_created: true` の時、同一ワークフロー内でビルド・publish まで完結させる。PAT も GitHub App も不要。

```
main へのマージ
  └─ release-please.yml が起動
       ├─ Release PR 作成/更新（通常時）
       └─ release_created: true のとき
            ├─ build-release（5プラットフォーム並列）→ GitHub Release にアップロード
            ├─ publish-crate（crates.io OIDC）
            ├─ build-npm（5プラットフォーム並列）
            ├─ publish-npm（npm OIDC）
            └─ publish-release（draft → 公開）
```

`release.yml` は手動トリガー専用フォールバックとして残す。