### PR TITLE
feat: MCPパラメータをserde構造体化、find_definitionsにmax_results追加

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1291,6 +1291,7 @@ dependencies = [
  "rayon",
  "regex",
  "regex-syntax",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,6 +31,7 @@ regex = "1"
 regex-syntax = "0.8"
 tempfile = "3"
 mimalloc = { version = "0.1", default-features = false }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 glob = "0.3"
 

--- a/rust/src/git.rs
+++ b/rust/src/git.rs
@@ -3,9 +3,23 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Create a git Command with hook-injected GIT_DIR/GIT_INDEX_FILE cleared.
+///
+/// Pre-commit hooks set GIT_DIR and GIT_INDEX_FILE in the environment. Without
+/// this cleanup, git subprocesses spawned from tests during the hook would use
+/// the hook's repository instead of the test's own temp git repo.
+pub(crate) fn git_cmd() -> Command {
+    let mut cmd = Command::new("git");
+    cmd.env_remove("GIT_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR");
+    cmd
+}
+
 /// Check if the directory is a git repository.
 pub fn is_git_repo(root: &Path) -> bool {
-    Command::new("git")
+    git_cmd()
         .args(["rev-parse", "--git-dir"])
         .current_dir(root)
         .output()
@@ -15,7 +29,7 @@ pub fn is_git_repo(root: &Path) -> bool {
 
 /// Get the git repository root directory.
 pub(crate) fn git_toplevel(root: &Path) -> Option<PathBuf> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(root)
         .output()
@@ -82,7 +96,7 @@ pub fn changed_files(root: &Path) -> Result<Vec<PathBuf>> {
     let mut files = HashSet::new();
 
     // unstaged changes
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["diff", "--name-only"])
         .current_dir(root)
         .output()?;
@@ -93,7 +107,7 @@ pub fn changed_files(root: &Path) -> Result<Vec<PathBuf>> {
     ));
 
     // staged changes
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["diff", "--cached", "--name-only"])
         .current_dir(root)
         .output()?;
@@ -115,7 +129,7 @@ pub fn since_files(root: &Path, duration: &str) -> Result<Vec<PathBuf>> {
     }
 
     let output = if let Some(since_str) = parse_duration(duration)? {
-        Command::new("git")
+        git_cmd()
             .args([
                 "log",
                 &format!("--since={since_str}"),
@@ -127,7 +141,7 @@ pub fn since_files(root: &Path, duration: &str) -> Result<Vec<PathBuf>> {
     } else {
         // commits mode: "3.commits" -> git log -3
         let n: &str = duration.split('.').next().unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["log", &format!("-{n}"), "--name-only", "--pretty=format:"])
             .current_dir(root)
             .output()?

--- a/rust/src/index/builder.rs
+++ b/rust/src/index/builder.rs
@@ -560,7 +560,7 @@ mod tests {
         fs::write(root.join("debug.log"), "should be ignored").unwrap();
 
         // Need to init git repo for .gitignore to work
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["init"])
             .current_dir(root)
             .output()

--- a/rust/src/index/updater.rs
+++ b/rust/src/index/updater.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::Result;
-use crate::git::git_toplevel;
+use crate::git::{git_cmd, git_toplevel};
 use ignore::WalkBuilder;
 
 /// Index freshness check result.
@@ -84,7 +84,7 @@ fn convert_git_path(prefix: &Option<PathBuf>, git_rel_path: &str) -> Option<Path
 
 /// Get the current git HEAD commit hash.
 fn current_commit_hash(root: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
+    let output = git_cmd()
         .args(["rev-parse", "HEAD"])
         .current_dir(root)
         .output()
@@ -189,7 +189,7 @@ fn collect_uncommitted_changes(root: &Path) -> Result<std::collections::HashSet<
 
     // Staged + unstaged changes (tracked files only)
     // -uno excludes untracked files to prevent hangs in large repositories
-    let output = std::process::Command::new("git")
+    let output = git_cmd()
         .args(["status", "--porcelain", "-uno"])
         .current_dir(root)
         .output()?;
@@ -204,7 +204,7 @@ fn collect_uncommitted_changes(root: &Path) -> Result<std::collections::HashSet<
     // Untracked files (fast enumeration respecting .gitignore)
     // Using ls-files --others instead of git status --porcelain
     // to stay fast even with large numbers of untracked files like node_modules
-    let output = std::process::Command::new("git")
+    let output = git_cmd()
         .args(["ls-files", "--others", "--exclude-standard"])
         .current_dir(root)
         .output()?;
@@ -229,7 +229,7 @@ fn changed_files_since(root: &Path, old_hash: &str) -> Result<Vec<PathBuf>> {
     let mut files = std::collections::HashSet::new();
 
     // Committed changes: old_hash..HEAD
-    let output = std::process::Command::new("git")
+    let output = git_cmd()
         .args([
             "diff-tree",
             "-r",
@@ -288,7 +288,7 @@ pub fn check_index_status(root: &Path, index_path: &Path) -> Result<IndexStatus>
                 // Same commit: only check staged/unstaged changes (fast path)
                 // Skip git ls-files --others to save ~170ms
                 let prefix = git_toplevel(root).and_then(|tl| root_prefix_in_git(&tl, root));
-                let output = std::process::Command::new("git")
+                let output = git_cmd()
                     .args(["status", "--porcelain", "-uno"])
                     .current_dir(root)
                     .output()?;
@@ -415,21 +415,16 @@ pub fn ensure_fresh_index(root: &Path, index_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::process::Command;
     use tempfile::tempdir;
 
     fn init_git_repo(dir: &Path) {
-        Command::new("git")
-            .args(["init"])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        Command::new("git")
+        git_cmd().args(["init"]).current_dir(dir).output().unwrap();
+        git_cmd()
             .args(["config", "user.email", "test@test.com"])
             .current_dir(dir)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["config", "user.name", "test"])
             .current_dir(dir)
             .output()
@@ -456,12 +451,12 @@ mod tests {
         // Add index files to .gitignore so git status does not detect them
         fs::write(root.join(".gitignore"), "*.xgrep\n*.meta\n*.cache\n").unwrap();
         fs::write(root.join("hello.txt"), "hello world").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -486,12 +481,12 @@ mod tests {
         let root = dir.path();
         init_git_repo(root);
         fs::write(root.join("hello.txt"), "hello world").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -505,12 +500,12 @@ mod tests {
         // Create a new commit
         std::thread::sleep(std::time::Duration::from_millis(100));
         fs::write(root.join("new_file.txt"), "new content").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "add file"])
             .current_dir(root)
             .output()
@@ -546,12 +541,12 @@ mod tests {
         let root = dir.path();
         init_git_repo(root);
         fs::write(root.join("hello.txt"), "hello world").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -578,12 +573,12 @@ mod tests {
         let root = dir.path();
         init_git_repo(root);
         fs::write(root.join("hello.txt"), "hello world").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -645,12 +640,12 @@ mod tests {
         init_git_repo(root);
         fs::write(root.join(".gitignore"), "*.xgrep\n*.meta\n*.cache\n").unwrap();
         fs::write(root.join("hello.txt"), "hello world").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -670,12 +665,12 @@ mod tests {
         init_git_repo(root);
         fs::write(root.join(".gitignore"), "*.xgrep\n*.meta\n*.cache\n").unwrap();
         fs::write(root.join("hello.txt"), "hello world").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -713,12 +708,12 @@ mod tests {
         init_git_repo(root);
         fs::write(root.join(".gitignore"), "*.xgrep\n*.meta\n*.cache\n").unwrap();
         fs::write(root.join("hello.txt"), "hello world").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -793,12 +788,12 @@ mod tests {
         init_git_repo(root);
         fs::write(root.join(".gitignore"), "*.xgrep\n*.meta\n*.cache\n").unwrap();
         fs::write(root.join("hello.txt"), "hello world").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -809,12 +804,12 @@ mod tests {
 
         // New commit
         fs::write(root.join("new_file.txt"), "new content").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "add file"])
             .current_dir(root)
             .output()
@@ -887,12 +882,12 @@ mod tests {
         fs::write(sub_dir.join("file.rs"), "fn main() {}").unwrap();
         fs::write(git_root.join("root_file.txt"), "root").unwrap();
 
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(git_root)
             .output()
@@ -941,12 +936,12 @@ mod tests {
         fs::write(git_root.join(".gitignore"), "*.xgrep\n*.meta\n*.cache\n").unwrap();
         fs::write(sub_dir.join("file.rs"), "fn main() {}").unwrap();
 
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(git_root)
             .output()
@@ -989,12 +984,12 @@ mod tests {
         fs::write(sub_dir.join("a.txt"), "hello").unwrap();
         fs::write(git_root.join("root.txt"), "root").unwrap();
 
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(git_root)
             .output()
@@ -1005,12 +1000,12 @@ mod tests {
         // New commit with changes in both locations
         fs::write(sub_dir.join("a.txt"), "changed").unwrap();
         fs::write(git_root.join("root.txt"), "changed root").unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["add", "."])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd()
             .args(["commit", "-m", "changes"])
             .current_dir(git_root)
             .output()

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -812,23 +812,21 @@ mod tests {
     /// --fresh search must not double the path (e.g., /repo/sub/sub/file).
     #[test]
     fn test_fresh_search_in_git_subdirectory_no_path_doubling() {
-        use std::process::Command;
-
         let dir = tempfile::tempdir().unwrap();
         let git_root = dir.path();
 
         // Initialize git repo at top level
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["init"])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.email", "test@test.com"])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.name", "test"])
             .current_dir(git_root)
             .output()
@@ -840,12 +838,12 @@ mod tests {
         std::fs::write(sub.join("hello.rs"), "pub fn hello() { }").unwrap();
 
         // Initial commit
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["add", "."])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["commit", "-m", "initial"])
             .current_dir(git_root)
             .output()
@@ -884,22 +882,20 @@ mod tests {
     /// Ensures search_changed also uses correct paths.
     #[test]
     fn test_changed_search_in_git_subdirectory() {
-        use std::process::Command;
-
         let dir = tempfile::tempdir().unwrap();
         let git_root = dir.path();
 
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["init"])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.email", "test@test.com"])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.name", "test"])
             .current_dir(git_root)
             .output()
@@ -909,12 +905,12 @@ mod tests {
         std::fs::create_dir_all(&sub).unwrap();
         std::fs::write(sub.join("lib.rs"), "fn original() {}").unwrap();
 
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["add", "."])
             .current_dir(git_root)
             .output()
             .unwrap();
-        Command::new("git")
+        crate::git::git_cmd()
             .args(["commit", "-m", "initial"])
             .current_dir(git_root)
             .output()
@@ -1102,7 +1098,7 @@ mod tests {
         // since_files() 経由でテストする
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["init"])
             .current_dir(root)
             .output()

--- a/rust/src/mcp.rs
+++ b/rust/src/mcp.rs
@@ -251,17 +251,17 @@ mod tests {
         let dir = tempdir().unwrap();
         let root = dir.path();
 
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["init"])
             .current_dir(root)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.email", "test@test.com"])
             .current_dir(root)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.name", "test"])
             .current_dir(root)
             .output()
@@ -274,12 +274,12 @@ mod tests {
         )
         .unwrap();
 
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()

--- a/rust/src/mcp_tools.rs
+++ b/rust/src/mcp_tools.rs
@@ -1,36 +1,51 @@
 //! MCP tool handlers for xgrep search operations.
 
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{output, SearchOptions, Xgrep};
 
-/// Validate that a JSON value, if present, is a non-negative integer.
-fn param_u64(params: &Value, key: &str) -> Result<Option<u64>, String> {
-    match params.get(key) {
-        None => Ok(None),
-        Some(v) if v.is_u64() => Ok(Some(v.as_u64().unwrap())),
-        Some(v) if v.is_i64() => {
-            let n = v.as_i64().unwrap();
-            if n >= 0 {
-                Ok(Some(n as u64))
-            } else {
-                Err(format!(
-                    "Parameter '{}' must be non-negative, got {}",
-                    key, n
-                ))
-            }
-        }
-        Some(v) => Err(format!("Parameter '{}' must be an integer, got {}", key, v)),
-    }
+fn default_max_results() -> usize {
+    20
+}
+fn default_context_lines() -> usize {
+    3
+}
+fn default_max_tokens() -> usize {
+    4000
 }
 
-/// Validate that a JSON value, if present, is a boolean.
-fn param_bool(params: &Value, key: &str) -> Result<Option<bool>, String> {
-    match params.get(key) {
-        None => Ok(None),
-        Some(v) if v.is_boolean() => Ok(Some(v.as_bool().unwrap())),
-        Some(v) => Err(format!("Parameter '{}' must be a boolean, got {}", key, v)),
-    }
+#[derive(Deserialize)]
+struct SearchParams {
+    pattern: String,
+    #[serde(default)]
+    regex: bool,
+    #[serde(default)]
+    case_insensitive: bool,
+    file_type: Option<String>,
+    path_pattern: Option<String>,
+    #[serde(default = "default_max_results")]
+    max_results: usize,
+    #[serde(default = "default_context_lines")]
+    context_lines: usize,
+    #[serde(default = "default_max_tokens")]
+    max_tokens: usize,
+}
+
+#[derive(Deserialize)]
+struct FindDefinitionsParams {
+    symbol: String,
+    file_type: Option<String>,
+    path_pattern: Option<String>,
+    #[serde(default = "default_max_results")]
+    max_results: usize,
+}
+
+#[derive(Deserialize)]
+struct ReadFileParams {
+    path: String,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
 }
 
 /// Return MCP tool definitions.
@@ -95,6 +110,10 @@ pub fn tools_list() -> Vec<Value> {
                     "path_pattern": {
                         "type": "string",
                         "description": "Filter by path substring"
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum number of results (default: 20)"
                     }
                 },
                 "required": ["symbol"]
@@ -134,48 +153,21 @@ pub fn tools_list() -> Vec<Value> {
 
 /// Handler for the `search` tool.
 pub fn handle_search(xg: &Xgrep, params: &Value) -> (String, bool) {
-    let pattern = match params.get("pattern").and_then(|v| v.as_str()) {
-        Some(p) => p,
-        None => return ("Missing required parameter: pattern".to_string(), true),
-    };
-
-    let max_results = match param_u64(params, "max_results") {
-        Ok(v) => v.unwrap_or(20) as usize,
-        Err(e) => return (e, true),
-    };
-    let context_lines = match param_u64(params, "context_lines") {
-        Ok(v) => v.unwrap_or(3) as usize,
-        Err(e) => return (e, true),
-    };
-    let max_tokens = match param_u64(params, "max_tokens") {
-        Ok(v) => v.unwrap_or(4000) as usize,
-        Err(e) => return (e, true),
-    };
-    let case_insensitive = match param_bool(params, "case_insensitive") {
-        Ok(v) => v.unwrap_or(false),
-        Err(e) => return (e, true),
-    };
-    let regex = match param_bool(params, "regex") {
-        Ok(v) => v.unwrap_or(false),
-        Err(e) => return (e, true),
+    let p: SearchParams = match serde_json::from_value(params.clone()) {
+        Ok(v) => v,
+        Err(e) => return (format!("Invalid parameters: {}", e), true),
     };
 
     let opts = SearchOptions {
-        case_insensitive,
-        regex,
-        file_type: params
-            .get("file_type")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        max_count: Some(max_results),
-        path_pattern: params
-            .get("path_pattern")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+        case_insensitive: p.case_insensitive,
+        regex: p.regex,
+        file_type: p.file_type,
+        max_count: Some(p.max_results),
+        path_pattern: p.path_pattern,
         ..Default::default()
     };
 
-    match xg.search(pattern, &opts) {
+    match xg.search(&p.pattern, &opts) {
         Ok(results) => {
             let file_count = {
                 let mut files = results.iter().map(|r| &r.file).collect::<Vec<_>>();
@@ -184,10 +176,10 @@ pub fn handle_search(xg: &Xgrep, params: &Value) -> (String, bool) {
                 files.len()
             };
             let total = results.len();
-            let header = if total == max_results {
+            let header = if total == p.max_results {
                 format!(
                     "Found {}+ matches in {} files (limited to {})\n\n",
-                    total, file_count, max_results
+                    total, file_count, p.max_results
                 )
             } else {
                 format!("Found {} matches in {} files\n\n", total, file_count)
@@ -195,9 +187,9 @@ pub fn handle_search(xg: &Xgrep, params: &Value) -> (String, bool) {
             match output::format_llm(
                 &results,
                 xg.root(),
-                context_lines,
-                context_lines,
-                Some(max_tokens),
+                p.context_lines,
+                p.context_lines,
+                Some(p.max_tokens),
                 false,
             ) {
                 Ok(body) => (format!("{}{}", header, body), false),
@@ -210,24 +202,18 @@ pub fn handle_search(xg: &Xgrep, params: &Value) -> (String, bool) {
 
 /// Handler for the `find_definitions` tool.
 pub fn handle_find_definitions(xg: &Xgrep, params: &Value) -> (String, bool) {
-    let symbol = match params.get("symbol").and_then(|v| v.as_str()) {
-        Some(s) => s,
-        None => return ("Missing required parameter: symbol".to_string(), true),
+    let p: FindDefinitionsParams = match serde_json::from_value(params.clone()) {
+        Ok(v) => v,
+        Err(e) => return (format!("Invalid parameters: {}", e), true),
     };
 
-    let pattern = definition_regex(symbol);
+    let pattern = definition_regex(&p.symbol);
 
     let opts = SearchOptions {
         regex: true,
-        file_type: params
-            .get("file_type")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        path_pattern: params
-            .get("path_pattern")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        max_count: Some(20),
+        file_type: p.file_type,
+        path_pattern: p.path_pattern,
+        max_count: Some(p.max_results),
         ..Default::default()
     };
 
@@ -239,12 +225,18 @@ pub fn handle_find_definitions(xg: &Xgrep, params: &Value) -> (String, bool) {
                 files.dedup();
                 files.len()
             };
-            let header = format!(
-                "Found {} definitions of '{}' in {} files\n\n",
-                results.len(),
-                symbol,
-                file_count
-            );
+            let total = results.len();
+            let header = if total == p.max_results {
+                format!(
+                    "Found {}+ definitions of '{}' in {} files (limited to {}, pass max_results to increase)\n\n",
+                    total, p.symbol, file_count, p.max_results
+                )
+            } else {
+                format!(
+                    "Found {} definitions of '{}' in {} files\n\n",
+                    total, p.symbol, file_count
+                )
+            };
             match output::format_llm(&results, xg.root(), 3, 3, None, false) {
                 Ok(body) => (format!("{}{}", header, body), false),
                 Err(e) => (format!("Format error: {}", e), true),
@@ -303,20 +295,20 @@ pub fn handle_index_status(xg: &Xgrep) -> (String, bool) {
 
 /// Handler for the `read_file` tool.
 pub fn handle_read_file(xg: &Xgrep, params: &Value) -> (String, bool) {
-    let path = match params.get("path").and_then(|p| p.as_str()) {
-        Some(p) => p,
-        None => return ("Missing required parameter: path".to_string(), true),
+    let p: ReadFileParams = match serde_json::from_value(params.clone()) {
+        Ok(v) => v,
+        Err(e) => return (format!("Invalid parameters: {}", e), true),
     };
 
-    let full_path = xg.root().join(path);
+    let full_path = xg.root().join(&p.path);
 
     // Security: prevent path traversal
     let canonical = match full_path.canonicalize() {
-        Ok(p) => p,
-        Err(e) => return (format!("Cannot read file '{}': {}", path, e), true),
+        Ok(c) => c,
+        Err(e) => return (format!("Cannot read file '{}': {}", p.path, e), true),
     };
     let root_canonical = match xg.root().canonicalize() {
-        Ok(p) => p,
+        Ok(c) => c,
         Err(e) => return (format!("Cannot resolve root: {}", e), true),
     };
     if !canonical.starts_with(&root_canonical) {
@@ -328,34 +320,29 @@ pub fn handle_read_file(xg: &Xgrep, params: &Value) -> (String, bool) {
 
     let content = match std::fs::read_to_string(&canonical) {
         Ok(c) => c,
-        Err(e) => return (format!("Cannot read file '{}': {}", path, e), true),
+        Err(e) => return (format!("Cannot read file '{}': {}", p.path, e), true),
     };
 
     let lines: Vec<&str> = content.lines().collect();
 
     if lines.is_empty() {
-        return (format!("## {}\n\nFile is empty.\n", path), false);
+        return (format!("## {}\n\nFile is empty.\n", p.path), false);
     }
 
-    let start = match param_u64(params, "start_line") {
-        Ok(v) => v.unwrap_or(1) as usize,
-        Err(e) => return (e, true),
-    };
-    let end = match param_u64(params, "end_line") {
-        Ok(v) => v.unwrap_or(lines.len() as u64) as usize,
-        Err(e) => return (e, true),
-    };
+    let start = p.start_line.unwrap_or(1).max(1).min(lines.len());
+    let end = p
+        .end_line
+        .unwrap_or(lines.len())
+        .max(start)
+        .min(lines.len());
 
-    let start = start.max(1).min(lines.len());
-    let end = end.max(start).min(lines.len());
-
-    let lang = std::path::Path::new(path)
+    let lang = std::path::Path::new(&p.path)
         .extension()
         .and_then(|e| e.to_str())
         .map(output::lang_from_ext)
         .unwrap_or("");
 
-    let mut output = format!("## {}:{}-{}\n\n```{}\n", path, start, end, lang);
+    let mut output = format!("## {}:{}-{}\n\n```{}\n", p.path, start, end, lang);
     for (i, line) in lines[start - 1..end].iter().enumerate() {
         output.push_str(&format!("{:4} | {}\n", start + i, line));
     }
@@ -397,17 +384,17 @@ mod tests {
         let root = dir.path();
 
         // git init
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["init"])
             .current_dir(root)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.email", "test@test.com"])
             .current_dir(root)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.name", "test"])
             .current_dir(root)
             .output()
@@ -425,12 +412,12 @@ mod tests {
         )
         .unwrap();
 
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -459,6 +446,65 @@ mod tests {
         assert!(!is_error);
         assert!(output.contains("hello"));
         assert!(output.contains("definitions"));
+    }
+
+    #[test]
+    fn test_handle_find_definitions_missing_symbol() {
+        let (_dir, xg) = setup_test_repo();
+        let params = serde_json::json!({});
+        let (output, is_error) = handle_find_definitions(&xg, &params);
+        assert!(is_error);
+        assert!(output.contains("Invalid parameters"));
+        assert!(output.contains("symbol"));
+    }
+
+    #[test]
+    fn test_handle_find_definitions_no_truncation() {
+        let (_dir, xg) = setup_test_repo();
+        // max_results=100 >> actual results (1), so no truncation signal
+        let params = serde_json::json!({"symbol": "hello", "max_results": 100});
+        let (output, is_error) = handle_find_definitions(&xg, &params);
+        assert!(!is_error, "unexpected error: {}", output);
+        assert!(output.contains("Found"));
+        assert!(output.contains("definitions"));
+        assert!(!output.contains("limited to"));
+    }
+
+    #[test]
+    fn test_handle_find_definitions_truncation_signal() {
+        let (dir, xg) = setup_test_repo();
+        // Add extra files so there are many fn/struct matches
+        fs::write(
+            dir.path().join("extra.rs"),
+            "fn hello() {}\nfn hello_world() {}\n",
+        )
+        .unwrap();
+        crate::git::git_cmd()
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        crate::git::git_cmd()
+            .args(["commit", "-m", "add extra"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        xg.build_index().unwrap();
+
+        // max_results=1 forces truncation when hello matches in both files
+        let params = serde_json::json!({"symbol": "hello", "max_results": 1});
+        let (output, is_error) = handle_find_definitions(&xg, &params);
+        assert!(!is_error, "unexpected error: {}", output);
+        assert!(
+            output.contains("limited to"),
+            "expected truncation signal in: {}",
+            output
+        );
+        assert!(
+            output.contains("max_results"),
+            "expected max_results hint in: {}",
+            output
+        );
     }
 
     #[test]
@@ -507,7 +553,8 @@ mod tests {
         let params = serde_json::json!({});
         let (output, is_error) = handle_search(&xg, &params);
         assert!(is_error);
-        assert!(output.contains("Missing required parameter: pattern"));
+        assert!(output.contains("Invalid parameters"));
+        assert!(output.contains("pattern"));
     }
 
     #[test]
@@ -516,17 +563,17 @@ mod tests {
         let root = dir.path();
 
         // git init
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["init"])
             .current_dir(root)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.email", "test@test.com"])
             .current_dir(root)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["config", "user.name", "test"])
             .current_dir(root)
             .output()
@@ -539,12 +586,12 @@ mod tests {
             .collect();
         fs::write(root.join("a.rs"), &content).unwrap();
 
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["add", "."])
             .current_dir(root)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::git::git_cmd()
             .args(["commit", "-m", "init"])
             .current_dir(root)
             .output()
@@ -650,7 +697,7 @@ mod tests {
         let params = serde_json::json!({"pattern": "hello", "max_results": "not_a_number"});
         let (output, is_error) = handle_search(&xg, &params);
         assert!(is_error);
-        assert!(output.contains("must be an integer"));
+        assert!(output.contains("Invalid parameters"));
     }
 
     #[test]
@@ -659,7 +706,7 @@ mod tests {
         let params = serde_json::json!({"pattern": "hello", "regex": "yes"});
         let (output, is_error) = handle_search(&xg, &params);
         assert!(is_error);
-        assert!(output.contains("must be a boolean"));
+        assert!(output.contains("Invalid parameters"));
     }
 
     #[test]
@@ -668,6 +715,6 @@ mod tests {
         let params = serde_json::json!({"pattern": "hello", "max_results": -5});
         let (output, is_error) = handle_search(&xg, &params);
         assert!(is_error);
-        assert!(output.contains("non-negative"));
+        assert!(output.contains("Invalid parameters"));
     }
 }

--- a/rust/tests/mcp_integration_test.rs
+++ b/rust/tests/mcp_integration_test.rs
@@ -178,7 +178,7 @@ fn test_mcp_input_validation_error() {
     let text = responses[1]["result"]["content"][0]["text"]
         .as_str()
         .unwrap();
-    assert!(text.contains("must be an integer"));
+    assert!(text.contains("Invalid parameters"));
     assert_eq!(responses[1]["result"]["isError"], true);
 }
 


### PR DESCRIPTION
## Summary

- `SearchParams` / `FindDefinitionsParams` / `ReadFileParams` の serde 構造体を導入し、手書きパラメータパースを削除
- `find_definitions` に `max_results` パラメータ（デフォルト20）を追加
- 上限到達時にトランケーションシグナルを出力（`Found N+ definitions ... (limited to N, pass max_results to increase)`）
- `git_cmd()` ヘルパーを追加し、pre-commit フックの `GIT_DIR`/`GIT_INDEX_FILE` 環境変数汚染をテストで防止

## 変更内容

- `rust/Cargo.toml`: `serde = { features = ["derive"] }` を追加
- `rust/src/mcp_tools.rs`: serde 構造体化、`find_definitions` の `max_results` + truncation signal
- `rust/tests/mcp_integration_test.rs`: エラーメッセージ検証を `"Invalid parameters"` に更新
- `rust/src/git.rs`: `git_cmd()` ヘルパー追加（`GIT_DIR` 等を unset）
- `rust/src/index/{updater,builder}.rs`, `rust/src/{lib,mcp}.rs`: 全 `Command::new("git")` を `git_cmd()` に統一

## テスト計画

- [x] `cargo test` 全 278 テスト通過確認済み
- [x] `cargo fmt --check` / `cargo clippy` 通過確認済み
- `find_definitions` の `max_results` パラメータを MCP クライアントから送信して動作確認