### PR TITLE
fix: release-please.yml のoutputをモノレポ用パス prefix付きキーに修正

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
+      release_created: ${{ steps.release.outputs['rust--release_created'] }}
+      tag_name: ${{ steps.release.outputs['rust--tag_name'] }}
+      version: ${{ steps.release.outputs['rust--version'] }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0


### PR DESCRIPTION
## Summary

- release-please-action v5 のモノレポ設定では出力名が `rust--release_created` 等にプレフィックスされる
- `steps.release.outputs.release_created` は常に空 → ビルド・パブリッシュジョブが全スキップされていた
- `steps.release.outputs['rust--release_created']` に修正

## 影響

v0.5.0 はタグ・GitHub Releaseが作成されたがバイナリなし → `release.yml` を手動 dispatch して対処済み

## テスト計画

- [ ] 次回リリースPRマージ時にビルドジョブが実行されることを確認