### PR TITLE
fix: build-pythonマトリクスからaarch64-linuxを除外

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,8 +298,6 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
           - os: macos-latest
@@ -323,16 +321,9 @@ jobs:
           python-version: "3.11"
       - name: Install maturin
         run: pip install "maturin==1.8.3"
-      - name: Install cross-compilation tools
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Build wheel
         working-directory: python
-        run: maturin build --release --target ${{ matrix.target }} --features extension-module -i python3
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: maturin build --release --target ${{ matrix.target }} --features extension-module
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## 概要

maturin 1.x はホストと異なるアーキテクチャへのクロスコンパイル時に Python インタープリターを認識できない（`Invalid python interpreter version`）。

aarch64-unknown-linux-gnu を build-python マトリクスから除外し、4プラットフォーム対応にする。

対象: x86_64-linux, aarch64-darwin, x86_64-darwin, x86_64-windows

## 対応プラットフォーム

| プラットフォーム | 対応 |
|---------|------|
| x86_64-linux | ✓ |
| aarch64-linux | 除外（maturinクロスコンパイル制限） |
| aarch64-darwin (Apple Silicon) | ✓ |
| x86_64-darwin | ✓ |
| x86_64-windows | ✓ |

## 備考

aarch64-linux は今後 QEMU または maturin-action を使った正式対応を検討する。