### PR TITLE
fix: RUSTSEC-2026-0097 修正（rand 更新）+ pip install ハッシュ固定

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,7 +320,13 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install maturin
-        run: pip install "maturin==1.8.3"
+        run: |
+          pip install "maturin==1.8.3" \
+            --hash=sha256:11564fac7486313b7baf3aa4e82c20e1b20364aad3fde2ccbc4c07693c0b7e16 \
+            --hash=sha256:583404d20d7f1d9c8f3c18dcab9014faacabbed6be02da80062c06cd0e279554 \
+            --hash=sha256:f9ffdac53dfe0089cf19b597410bc552eb34c856ddb41482b243a695e8b549d3 \
+            --hash=sha256:85f2b882d8235c1c1cb0a38d382ccd5b3ba0674d99cb548d49df9342cc688e36 \
+            --hash=sha256:304762f86fd53a8031b1bf006d12572a2aa0a5235485031113195cc0152e1e12
       - name: Build wheel
         working-directory: python
         run: maturin build --release --target ${{ matrix.target }} --features extension-module
@@ -354,7 +360,13 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install maturin
-        run: pip install "maturin==1.8.3"
+        run: |
+          pip install "maturin==1.8.3" \
+            --hash=sha256:11564fac7486313b7baf3aa4e82c20e1b20364aad3fde2ccbc4c07693c0b7e16 \
+            --hash=sha256:583404d20d7f1d9c8f3c18dcab9014faacabbed6be02da80062c06cd0e279554 \
+            --hash=sha256:f9ffdac53dfe0089cf19b597410bc552eb34c856ddb41482b243a695e8b549d3 \
+            --hash=sha256:85f2b882d8235c1c1cb0a38d382ccd5b3ba0674d99cb548d49df9342cc688e36 \
+            --hash=sha256:304762f86fd53a8031b1bf006d12572a2aa0a5235485031113195cc0152e1e12
       - name: Download all Python wheels
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -712,9 +712,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "xgrep-search"
-version = "0.6.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1291,7 +1291,6 @@ dependencies = [
  "rayon",
  "regex",
  "regex-syntax",
- "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",


### PR DESCRIPTION
## 概要

Scorecard の残留アラートに対応。

## 変更内容

### rand 0.9.2 → 0.9.4（RUSTSEC-2026-0097）
- `rust/Cargo.lock`: rand を 0.9.2 → 0.9.4 に更新
- 脆弱性: `rand::rng()` をカスタムロガーと組み合わせた際の unsound 動作
- パッチバージョン: >=0.9.3 で修正済み

### maturin pip install にハッシュ固定を追加（Scorecard PinnedDependencies #18, #19）
- `release.yml` の build-python / publish-pypi ジョブの `pip install maturin==1.8.3` に全プラットフォームの SHA256 を付与
- 対象ホイール: linux x86_64 / macos universal2 / macos x86_64 / win_amd64 / sdist

## テスト計画
- [ ] CI の cargo audit が通ることを確認
- [ ] Scorecard 再スキャンでアラートが減少することを確認